### PR TITLE
Changed method names

### DIFF
--- a/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/ActionAttributesTestBuilderExtensions.cs
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/ActionAttributesTestBuilderExtensions.cs
@@ -28,7 +28,7 @@
         public static IAndActionAttributesTestBuilder ChangingActionNameTo(
             this IActionAttributesTestBuilder actionAttributesTestBuilder,
             string actionName)
-        => SpecifyingActionName(actionAttributesTestBuilder, actionName);
+            => SpecifyingActionName(actionAttributesTestBuilder, actionName);
 
         /// <summary>
         /// Tests whether the action attributes contain <see cref="ActionNameAttribute"/>.

--- a/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/ActionAttributesTestBuilderExtensions.cs
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/ActionAttributesTestBuilderExtensions.cs
@@ -24,7 +24,21 @@
         /// </param>
         /// <param name="actionName">Expected overridden name of the action.</param>
         /// <returns>The same <see cref="IAndActionAttributesTestBuilder"/>.</returns>
+        [Obsolete("This method will be removed in the next major version, please use SpecifyingActionName")]
         public static IAndActionAttributesTestBuilder ChangingActionNameTo(
+            this IActionAttributesTestBuilder actionAttributesTestBuilder,
+            string actionName)
+        => SpecifyingActionName(actionAttributesTestBuilder, actionName);
+
+        /// <summary>
+        /// Tests whether the action attributes contain <see cref="ActionNameAttribute"/>.
+        /// </summary>
+        /// <param name="actionAttributesTestBuilder">
+        /// Instance of <see cref="IActionAttributesTestBuilder"/> type.
+        /// </param>
+        /// <param name="actionName">Expected overridden name of the action.</param>
+        /// <returns>The same <see cref="IAndActionAttributesTestBuilder"/>.</returns>
+        public static IAndActionAttributesTestBuilder SpecifyingActionName(
             this IActionAttributesTestBuilder actionAttributesTestBuilder,
             string actionName)
         {

--- a/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/ControllerActionAttributesTestBuilderExtensions.cs
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/ControllerActionAttributesTestBuilderExtensions.cs
@@ -25,14 +25,49 @@
         /// <param name="withName">Optional expected route name.</param>
         /// <param name="withOrder">Optional expected route order.</param>
         /// <returns>The same attributes test builder.</returns>
+       [Obsolete("This method will be removed in the next major version, please use SpecifyingRoute")]
         public static TAttributesTestBuilder ChangingRouteTo<TAttributesTestBuilder>(
             this IControllerActionAttributesTestBuilder<TAttributesTestBuilder> controllerActionAttributesTestBuilder,
             string template,
             string withName = null,
             int? withOrder = null)
             where TAttributesTestBuilder : IControllerActionAttributesTestBuilder<TAttributesTestBuilder>
+            => SpecifyingRoute(controllerActionAttributesTestBuilder, template, withName, withOrder);
+
+
+        /// <summary>
+        /// Tests whether the collected attributes contain <see cref="RouteAttribute"/>.
+        /// </summary>
+        /// <param name="controllerActionAttributesTestBuilder">
+        /// Instance of <see cref="IControllerActionAttributesTestBuilder{TAttributesTestBuilder}"/> type.
+        /// </param>
+        /// <param name="routeAttributeBuilder">Expected <see cref="RouteAttribute"/> builder.</param>
+        /// <returns>The same attributes test builder.</returns>
+        [Obsolete("This method will be removed in the next major version, please use SpecifyingRoute")]
+        public static TAttributesTestBuilder ChangingRouteTo<TAttributesTestBuilder>(
+            this IControllerActionAttributesTestBuilder<TAttributesTestBuilder> controllerActionAttributesTestBuilder,
+            Action<IRouteAttributeTestBuilder> routeAttributeBuilder)
+            where TAttributesTestBuilder : IControllerActionAttributesTestBuilder<TAttributesTestBuilder>
+            => SpecifyingRoute(controllerActionAttributesTestBuilder, routeAttributeBuilder);
+
+        /// <summary>
+        /// Tests whether the collected attributes contain <see cref="RouteAttribute"/>.
+        /// </summary>
+        /// <param name="controllerActionAttributesTestBuilder">
+        /// Instance of <see cref="IControllerActionAttributesTestBuilder{TAttributesTestBuilder}"/> type.
+        /// </param>
+        /// <param name="template">Expected overridden route template of the controller.</param>
+        /// <param name="withName">Optional expected route name.</param>
+        /// <param name="withOrder">Optional expected route order.</param>
+        /// <returns>The same attributes test builder.</returns>
+        public static TAttributesTestBuilder SpecifyingRoute<TAttributesTestBuilder>(
+            this IControllerActionAttributesTestBuilder<TAttributesTestBuilder> controllerActionAttributesTestBuilder,
+            string template,
+            string withName = null,
+            int? withOrder = null)
+            where TAttributesTestBuilder : IControllerActionAttributesTestBuilder<TAttributesTestBuilder>
             => controllerActionAttributesTestBuilder
-                .ChangingRouteTo(route => route
+                .SpecifyingRoute(route => route
                     .WithTemplate(template)
                     .WithName(withName)
                     .WithOrder(withOrder ?? 0));
@@ -45,7 +80,7 @@
         /// </param>
         /// <param name="routeAttributeBuilder">Expected <see cref="RouteAttribute"/> builder.</param>
         /// <returns>The same attributes test builder.</returns>
-        public static TAttributesTestBuilder ChangingRouteTo<TAttributesTestBuilder>(
+        public static TAttributesTestBuilder SpecifyingRoute<TAttributesTestBuilder>(
             this IControllerActionAttributesTestBuilder<TAttributesTestBuilder> controllerActionAttributesTestBuilder,
             Action<IRouteAttributeTestBuilder> routeAttributeBuilder)
             where TAttributesTestBuilder : IControllerActionAttributesTestBuilder<TAttributesTestBuilder>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/BuildersTests/AttributesTests/ActionAttributesTestBuilderTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/BuildersTests/AttributesTests/ActionAttributesTestBuilderTests.cs
@@ -20,7 +20,7 @@
                 .Instance()
                 .Calling(c => c.VariousAttributesAction())
                 .ShouldHave()
-                .ActionAttributes(attributes => attributes.ChangingRouteTo("/api/test"));
+                .ActionAttributes(attributes => attributes.SpecifyingRoute("/api/test"));
         }
 
         [Fact]
@@ -30,7 +30,7 @@
                 .Instance()
                 .Calling(c => c.VariousAttributesAction())
                 .ShouldHave()
-                .ActionAttributes(attributes => attributes.ChangingRouteTo("/api/Test"));
+                .ActionAttributes(attributes => attributes.SpecifyingRoute("/api/Test"));
         }
 
         [Fact]
@@ -43,7 +43,7 @@
                         .Instance()
                         .Calling(c => c.VariousAttributesAction())
                         .ShouldHave()
-                        .ActionAttributes(attributes => attributes.ChangingRouteTo("/api/another"));
+                        .ActionAttributes(attributes => attributes.SpecifyingRoute("/api/another"));
                 },
                 "When calling VariousAttributesAction action in MvcController expected action to have RouteAttribute with '/api/another' template, but in fact found '/api/test'.");
         }
@@ -55,7 +55,7 @@
                 .Instance()
                 .Calling(c => c.VariousAttributesAction())
                 .ShouldHave()
-                .ActionAttributes(attributes => attributes.ChangingRouteTo("/api/test", withName: "TestRoute"));
+                .ActionAttributes(attributes => attributes.SpecifyingRoute("/api/test", withName: "TestRoute"));
         }
 
         [Fact]
@@ -68,7 +68,7 @@
                         .Instance()
                         .Calling(c => c.VariousAttributesAction())
                         .ShouldHave()
-                        .ActionAttributes(attributes => attributes.ChangingRouteTo("/api/test", withName: "AnotherRoute"));
+                        .ActionAttributes(attributes => attributes.SpecifyingRoute("/api/test", withName: "AnotherRoute"));
                 },
                 "When calling VariousAttributesAction action in MvcController expected action to have RouteAttribute with 'AnotherRoute' name, but in fact found 'TestRoute'.");
         }
@@ -80,7 +80,7 @@
                 .Instance()
                 .Calling(c => c.VariousAttributesAction())
                 .ShouldHave()
-                .ActionAttributes(attributes => attributes.ChangingRouteTo("/api/test", withOrder: 1));
+                .ActionAttributes(attributes => attributes.SpecifyingRoute("/api/test", withOrder: 1));
         }
 
         [Fact]
@@ -93,7 +93,7 @@
                         .Instance()
                         .Calling(c => c.VariousAttributesAction())
                         .ShouldHave()
-                        .ActionAttributes(attributes => attributes.ChangingRouteTo("/api/test", withOrder: 2));
+                        .ActionAttributes(attributes => attributes.SpecifyingRoute("/api/test", withOrder: 2));
                 },
                 "When calling VariousAttributesAction action in MvcController expected action to have RouteAttribute with order of 2, but in fact found 1.");
         }
@@ -108,7 +108,7 @@
                         .Instance()
                         .Calling(c => c.NormalActionWithAttributes())
                         .ShouldHave()
-                        .ActionAttributes(attributes => attributes.ChangingRouteTo("/api/test"));
+                        .ActionAttributes(attributes => attributes.SpecifyingRoute("/api/test"));
                 },
                 "When calling NormalActionWithAttributes action in MvcController expected action to have RouteAttribute, but in fact such was not found.");
         }
@@ -120,7 +120,7 @@
                 .Instance()
                 .Calling(c => c.VariousAttributesAction())
                 .ShouldHave()
-                .ActionAttributes(attributes => attributes.ChangingActionNameTo("NormalAction"));
+                .ActionAttributes(attributes => attributes.SpecifyingActionName("NormalAction"));
         }
 
         [Fact]
@@ -133,7 +133,7 @@
                         .Instance()
                         .Calling(c => c.VariousAttributesAction())
                         .ShouldHave()
-                        .ActionAttributes(attributes => attributes.ChangingActionNameTo("AnotherAction"));
+                        .ActionAttributes(attributes => attributes.SpecifyingActionName("AnotherAction"));
                 },
                 "When calling VariousAttributesAction action in MvcController expected action to have ActionNameAttribute with 'AnotherAction' name, but in fact found 'NormalAction'.");
         }
@@ -148,7 +148,7 @@
                         .Instance()
                         .Calling(c => c.NormalActionWithAttributes())
                         .ShouldHave()
-                        .ActionAttributes(attributes => attributes.ChangingActionNameTo("NormalAction"));
+                        .ActionAttributes(attributes => attributes.SpecifyingActionName("NormalAction"));
                 },
                 "When calling NormalActionWithAttributes action in MvcController expected action to have ActionNameAttribute, but in fact such was not found.");
         }
@@ -1850,7 +1850,7 @@
                 .Instance()
                 .Calling(c => c.EmptyActionWithParameters(With.No<int>(), With.No<RequestModel>()))
                 .ShouldHave()
-                .ActionAttributes(attributes => attributes.ChangingActionNameTo("Test"));
+                .ActionAttributes(attributes => attributes.SpecifyingActionName("Test"));
         }
 
         [Fact]
@@ -1865,7 +1865,7 @@
                         .AllowingAnonymousRequests()
                         .AndAlso()
                         .DisablingActionCall()
-                        .ChangingActionNameTo("NormalAction"));
+                        .SpecifyingActionName("NormalAction"));
         }
     }
 }

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/BuildersTests/AttributesTests/ControllerAttributesTestBuilderTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/BuildersTests/AttributesTests/ControllerAttributesTestBuilderTests.cs
@@ -16,7 +16,7 @@
         {
             MyController<AttributesController>
                 .ShouldHave()
-                .Attributes(attributes => attributes.ChangingRouteTo("api/test"));
+                .Attributes(attributes => attributes.SpecifyingRoute("api/test"));
         }
 
         [Fact]
@@ -24,7 +24,7 @@
         {
             MyController<AttributesController>
                 .ShouldHave()
-                .Attributes(attributes => attributes.ChangingRouteTo("api/Test"));
+                .Attributes(attributes => attributes.SpecifyingRoute("api/Test"));
         }
 
         [Fact]
@@ -33,7 +33,7 @@
             MyController<AttributesController>
                 .ShouldHave()
                 .Attributes(attributes => attributes
-                    .ChangingRouteTo(route => route
+                    .SpecifyingRoute(route => route
                         .WithOrder(1)
                         .AndAlso()
                         .WithName("TestRouteAttributes")
@@ -49,7 +49,7 @@
                 {
                     MyController<AttributesController>
                         .ShouldHave()
-                        .Attributes(attributes => attributes.ChangingRouteTo("api/another"));
+                        .Attributes(attributes => attributes.SpecifyingRoute("api/another"));
                 },
                 "When testing AttributesController was expected to have RouteAttribute with 'api/another' template, but in fact found 'api/test'.");
         }
@@ -59,7 +59,7 @@
         {
             MyController<AttributesController>
                 .ShouldHave()
-                .Attributes(attributes => attributes.ChangingRouteTo("api/test", withName: "TestRouteAttributes"));
+                .Attributes(attributes => attributes.SpecifyingRoute("api/test", withName: "TestRouteAttributes"));
         }
 
         [Fact]
@@ -70,7 +70,7 @@
                 {
                     MyController<AttributesController>
                         .ShouldHave()
-                        .Attributes(attributes => attributes.ChangingRouteTo("api/test", withName: "AnotherRoute"));
+                        .Attributes(attributes => attributes.SpecifyingRoute("api/test", withName: "AnotherRoute"));
                 },
                 "When testing AttributesController was expected to have RouteAttribute with 'AnotherRoute' name, but in fact found 'TestRouteAttributes'.");
         }
@@ -80,7 +80,7 @@
         {
             MyController<AttributesController>
                 .ShouldHave()
-                .Attributes(attributes => attributes.ChangingRouteTo("api/test", withOrder: 1));
+                .Attributes(attributes => attributes.SpecifyingRoute("api/test", withOrder: 1));
         }
 
         [Fact]
@@ -91,7 +91,7 @@
                 {
                     MyController<AttributesController>
                         .ShouldHave()
-                        .Attributes(attributes => attributes.ChangingRouteTo("api/test", withOrder: 2));
+                        .Attributes(attributes => attributes.SpecifyingRoute("api/test", withOrder: 2));
                 },
                 "When testing AttributesController was expected to have RouteAttribute with order of 2, but in fact found 1.");
         }
@@ -104,7 +104,7 @@
                 {
                     MyController<AreaController>
                         .ShouldHave()
-                        .Attributes(attributes => attributes.ChangingRouteTo("api/test"));
+                        .Attributes(attributes => attributes.SpecifyingRoute("api/test"));
                 },
                 "When testing AreaController was expected to have RouteAttribute, but in fact such was not found.");
         }
@@ -1496,7 +1496,7 @@
                     => attributes
                         .AllowingAnonymousRequests()
                         .AndAlso()
-                        .ChangingRouteTo("api/test"));
+                        .SpecifyingRoute("api/test"));
         }
     }
 }


### PR DESCRIPTION
New methods SpecifyingActionName and SpecifyingRoute added in place of ChangingActionNameTo and ChangingRouteTo. Old methods are marked as obsolete - #240