### PR TITLE
Removed Language Specific Dependency On Certain Tests

### DIFF
--- a/test/MyTested.AspNetCore.Mvc.Abstractions.Test/ServicesTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Abstractions.Test/ServicesTests.cs
@@ -174,7 +174,7 @@
 
                     TestServiceProvider.GetService<IInjectedService>();
                 },
-                "Testing services could not be resolved. If your ConfigureServices method returns an IServiceProvider, you should either change it to return 'void' or manually register the required testing services by calling one of the provided IServiceCollection extension methods in the 'MyTested.AspNetCore.Mvc' namespace.");
+                "Testing services could not be resolved. If your ConfigureServices method returns an IServiceProvider, you should either change it to return 'void' or manually register the required testing services by calling one of the provided IServiceCollection extension methods in the 'MyTested.AspNetCore.Mvc' namespace. An easy way to do the second option is to add a TestStartup class at the root of your test project and invoke the extension methods there.");
 
             MyApplication.StartsFrom<DefaultStartup>();
         }

--- a/test/MyTested.AspNetCore.Mvc.Abstractions.Test/UtilitiesTests/ReflectionTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Abstractions.Test/UtilitiesTests/ReflectionTests.cs
@@ -1025,7 +1025,7 @@
             Assert.False(Reflection.AreDeeplyEqual(1, "1", out result));
             Assert.Equal("Expected a value of Int32 type, but in fact it was String", result.ToString());
             Assert.False(Reflection.AreDeeplyEqual(new DateTime(2015, 10, 19), new DateTime(2015, 10, 20), out result));
-            Assert.Equal("Difference occurs at 'DateTime.== (Equality Operator)'. Expected a value of '10/19/2015 12:00:00 AM', but in fact it was '10/20/2015 12:00:00 AM'", result.ToString());
+            Assert.Equal($"Difference occurs at 'DateTime.== (Equality Operator)'. Expected a value of '{new DateTime(2015, 10, 19)}', but in fact it was '{new DateTime(2015, 10, 20)}'", result.ToString());
         }
 
         [Fact]

--- a/test/MyTested.AspNetCore.Mvc.Caching.Test/BuildersTests/ActionsTests/ShouldHaveTests/ShouldHaveMemoryCacheTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Caching.Test/BuildersTests/ActionsTests/ShouldHaveTests/ShouldHaveMemoryCacheTests.cs
@@ -268,7 +268,8 @@
         [Fact]
         public void MemoryCacheWithBuilderShouldThrowWithMemoryCacheEntryOptionsWithInvalidAbsoluteExpiration()
         {
-            var invalidExpirationDate = new DateTime(2017, 1, 1, 1, 1, 1, DateTimeKind.Utc);
+            var invalidExpirationDate = new DateTimeOffset(new DateTime(2017, 1, 1, 1, 1, 1, DateTimeKind.Utc));
+            var actualExpirationDate = new DateTimeOffset(new DateTime(2016, 1, 1, 1, 1, 1, DateTimeKind.Utc));
 
             Test.AssertException<DataProviderAssertionException>(
                 () =>
@@ -280,7 +281,7 @@
                         .MemoryCache(cache => cache
                             .ContainingEntry("test", "value", new MemoryCacheEntryOptions
                             {
-                                AbsoluteExpiration = new DateTimeOffset(invalidExpirationDate),
+                                AbsoluteExpiration = invalidExpirationDate,
                                 AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1),
                                 Priority = CacheItemPriority.High,
                                 SlidingExpiration = TimeSpan.FromMinutes(5)
@@ -289,7 +290,7 @@
                         .ShouldReturn()
                         .Ok();
                 },
-                "When calling AddMemoryCacheAction action in MvcController expected memory cache to have entry with the given options, but in fact they were different. Difference occurs at 'MemoryCacheEntryOptions.AbsoluteExpiration.== (Equality Operator)'. Expected a value of '1/1/2017 1:01:01 AM +00:00', but in fact it was '1/1/2016 1:01:01 AM +00:00'.");
+                $"When calling AddMemoryCacheAction action in MvcController expected memory cache to have entry with the given options, but in fact they were different. Difference occurs at 'MemoryCacheEntryOptions.AbsoluteExpiration.== (Equality Operator)'. Expected a value of '{invalidExpirationDate}', but in fact it was '{actualExpirationDate}'.");
         }
 
         [Fact]

--- a/test/MyTested.AspNetCore.Mvc.Caching.Test/BuildersTests/InvocationsTests/ShouldHaveTests/ShouldHaveMemoryCacheTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Caching.Test/BuildersTests/InvocationsTests/ShouldHaveTests/ShouldHaveMemoryCacheTests.cs
@@ -242,7 +242,8 @@
         [Fact]
         public void MemoryCacheWithBuilderShouldThrowWithMemoryCacheEntryOptionsWithInvalidAbsoluteExpiration()
         {
-            var invalidExpirationDate = new DateTime(2017, 1, 1, 1, 1, 1, DateTimeKind.Utc);
+            var invalidExpirationDate = new DateTimeOffset(new DateTime(2017, 1, 1, 1, 1, 1, DateTimeKind.Utc));
+            var actualExpirationDate = new DateTimeOffset(new DateTime(2016, 1, 1, 1, 1, 1, DateTimeKind.Utc));
 
             Test.AssertException<DataProviderAssertionException>(
                 () =>
@@ -253,7 +254,7 @@
                         .MemoryCache(cache => cache
                             .ContainingEntry("test", "value", new MemoryCacheEntryOptions
                             {
-                                AbsoluteExpiration = new DateTimeOffset(invalidExpirationDate),
+                                AbsoluteExpiration = invalidExpirationDate,
                                 AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1),
                                 Priority = CacheItemPriority.High,
                                 SlidingExpiration = TimeSpan.FromMinutes(5)
@@ -262,7 +263,7 @@
                         .ShouldReturn()
                         .View();
                 },
-                "When invoking MemoryCacheValuesComponent expected memory cache to have entry with the given options, but in fact they were different. Difference occurs at 'MemoryCacheEntryOptions.AbsoluteExpiration.== (Equality Operator)'. Expected a value of '1/1/2017 1:01:01 AM +00:00', but in fact it was '1/1/2016 1:01:01 AM +00:00'.");
+                $"When invoking MemoryCacheValuesComponent expected memory cache to have entry with the given options, but in fact they were different. Difference occurs at 'MemoryCacheEntryOptions.AbsoluteExpiration.== (Equality Operator)'. Expected a value of '{invalidExpirationDate}', but in fact it was '{actualExpirationDate}'.");
         }
 
         [Fact]

--- a/test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test/BuildersTests/ActionResultsTests/JsonTests/JsonSerializerTestBuilderTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test/BuildersTests/ActionResultsTests/JsonTests/JsonSerializerTestBuilderTests.cs
@@ -109,7 +109,7 @@
                             .WithJsonSerializerSettings(s =>
                                 s.WithCulture(CultureInfo.GetCultureInfo("en-US"))));
                 },
-                "When calling JsonWithSettingsAction action in MvcController expected JSON result serializer settings to have 'English (United States)' culture, but in fact found 'Unknown language'.");
+                $"When calling JsonWithSettingsAction action in MvcController expected JSON result serializer settings to have '{CultureInfo.GetCultureInfo("en-US").DisplayName}' culture, but in fact found '{CultureInfo.InvariantCulture.DisplayName}'.");
         }
 
         [Fact]


### PR DESCRIPTION
Tests failed if OS was not running EN-US language.
changed a few tests to not depend strongly on a specific language.