### PR TITLE
Add .NET 6 Support

### DIFF
--- a/plugins/MyTested.AspNetCore.Mvc.NewtonsoftJson/MyTested.AspNetCore.Mvc.NewtonsoftJson.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.NewtonsoftJson/MyTested.AspNetCore.Mvc.NewtonsoftJson.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.NewtonsoftJson</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/plugins/MyTested.AspNetCore.Mvc.NewtonsoftJson/MyTested.AspNetCore.Mvc.NewtonsoftJson.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.NewtonsoftJson/MyTested.AspNetCore.Mvc.NewtonsoftJson.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.1" />
   </ItemGroup>
     
   <ItemGroup>

--- a/plugins/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/plugins/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/MyTested.AspNetCore.Mvc.Versioning.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/MyTested.AspNetCore.Mvc.Versioning.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Versioning</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/samples/ApplicationParts/ApplicationParts.Controllers/ApplicationParts.Controllers.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Controllers/ApplicationParts.Controllers.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/ApplicationParts/ApplicationParts.Controllers/ApplicationParts.Controllers.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Controllers/ApplicationParts.Controllers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>ApplicationParts.Controllers</AssemblyName>
     <PackageId>ApplicationParts.Controllers</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/samples/ApplicationParts/ApplicationParts.Models/ApplicationParts.Models.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Models/ApplicationParts.Models.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/ApplicationParts/ApplicationParts.Models/ApplicationParts.Models.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Models/ApplicationParts.Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>ApplicationParts.Models</AssemblyName>
     <PackageId>ApplicationParts.Models</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/samples/ApplicationParts/ApplicationParts.Services/ApplicationParts.Services.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Services/ApplicationParts.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>ApplicationParts.Services</AssemblyName>
     <PackageId>ApplicationParts.Services</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/samples/ApplicationParts/ApplicationParts.Test/ApplicationParts.Test.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Test/ApplicationParts.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/ApplicationParts/ApplicationParts.Test/ApplicationParts.Test.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Test/ApplicationParts.Test.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>

--- a/samples/ApplicationParts/ApplicationParts.Web/ApplicationParts.Web.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Web/ApplicationParts.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<AssemblyName>ApplicationParts.Web</AssemblyName>
 		<UserSecretsId>aspnet-ApplicationParts.Web-c273a372-79ef-490d-b0e1-a7fb8f2dacc7</UserSecretsId>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/samples/ApplicationParts/ApplicationParts.Web/ApplicationParts.Web.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Web/ApplicationParts.Web.csproj
@@ -18,19 +18,19 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.8" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.8">
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/samples/Autofac/Autofac.AssemblyInit.Test/Autofac.AssemblyInit.Test.csproj
+++ b/samples/Autofac/Autofac.AssemblyInit.Test/Autofac.AssemblyInit.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>

--- a/samples/Autofac/Autofac.AssemblyInit.Test/Autofac.AssemblyInit.Test.csproj
+++ b/samples/Autofac/Autofac.AssemblyInit.Test/Autofac.AssemblyInit.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/samples/Autofac/Autofac.NoContainerBuilder.Test/Autofac.NoContainerBuilder.Test.csproj
+++ b/samples/Autofac/Autofac.NoContainerBuilder.Test/Autofac.NoContainerBuilder.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Autofac/Autofac.NoContainerBuilder.Test/Autofac.NoContainerBuilder.Test.csproj
+++ b/samples/Autofac/Autofac.NoContainerBuilder.Test/Autofac.NoContainerBuilder.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Autofac/Autofac.NoContainerBuilder.Web/Autofac.NoContainerBuilder.Web.csproj
+++ b/samples/Autofac/Autofac.NoContainerBuilder.Web/Autofac.NoContainerBuilder.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/samples/Autofac/Autofac.NoContainerBuilder.Web/Startup.cs
+++ b/samples/Autofac/Autofac.NoContainerBuilder.Web/Startup.cs
@@ -29,7 +29,7 @@
 
             services.AddSingleton<IDateTimeService>(_ => new DateTimeService());
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            services.AddMvc();
             
             var builder = this.GetContainerBuilder(services);
 

--- a/samples/Autofac/Autofac.Test/Autofac.Test.csproj
+++ b/samples/Autofac/Autofac.Test/Autofac.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Autofac/Autofac.Test/Autofac.Test.csproj
+++ b/samples/Autofac/Autofac.Test/Autofac.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Autofac/Autofac.Web/Autofac.Web.csproj
+++ b/samples/Autofac/Autofac.Web/Autofac.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/samples/Autofac/Autofac.Web/Startup.cs
+++ b/samples/Autofac/Autofac.Web/Startup.cs
@@ -27,7 +27,7 @@
 
             services.AddSingleton<IDateTimeService>(_ => new DateTimeService());
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            services.AddMvc();
         }
 
         public void ConfigureContainer(ContainerBuilder builder) 

--- a/samples/Blog/Blog.Controllers/Blog.Controllers.csproj
+++ b/samples/Blog/Blog.Controllers/Blog.Controllers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/Blog/Blog.Data/Blog.Data.csproj
+++ b/samples/Blog/Blog.Data/Blog.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/Blog/Blog.Data/Blog.Data.csproj
+++ b/samples/Blog/Blog.Data/Blog.Data.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/Blog/Blog.Services/Blog.Services.csproj
+++ b/samples/Blog/Blog.Services/Blog.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/Blog/Blog.Test/Blog.Test.csproj
+++ b/samples/Blog/Blog.Test/Blog.Test.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/samples/Blog/Blog.Test/Blog.Test.csproj
+++ b/samples/Blog/Blog.Test/Blog.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Blog/Blog.Web/Blog.Web.csproj
+++ b/samples/Blog/Blog.Web/Blog.Web.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.8" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Blog/Blog.Web/Blog.Web.csproj
+++ b/samples/Blog/Blog.Web/Blog.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>aspnet-Blog.Web-6757ED6F-7F48-4961-917B-ADA8F5DEAFB4</UserSecretsId>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/samples/Configuration/Common/AdditionalEntryPoint.csproj
+++ b/samples/Configuration/Common/AdditionalEntryPoint.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Configuration/Common/AdditionalEntryPoint.csproj
+++ b/samples/Configuration/Common/AdditionalEntryPoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsTestProject>false</IsTestProject>
     <IsPackable>false</IsPackable>

--- a/samples/Configuration/Test.DifferentEnvironment/Test.DifferentEnvironment.csproj
+++ b/samples/Configuration/Test.DifferentEnvironment/Test.DifferentEnvironment.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Configuration/Test.DifferentEnvironment/Test.DifferentEnvironment.csproj
+++ b/samples/Configuration/Test.DifferentEnvironment/Test.DifferentEnvironment.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.ExplicitNoStartupType/Test.ExplicitNoStartupType.csproj
+++ b/samples/Configuration/Test.ExplicitNoStartupType/Test.ExplicitNoStartupType.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Configuration/Test.ExplicitNoStartupType/Test.ExplicitNoStartupType.csproj
+++ b/samples/Configuration/Test.ExplicitNoStartupType/Test.ExplicitNoStartupType.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.MissingStartupType/Test.MissingStartupType.csproj
+++ b/samples/Configuration/Test.MissingStartupType/Test.MissingStartupType.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Configuration/Test.MissingStartupType/Test.MissingStartupType.csproj
+++ b/samples/Configuration/Test.MissingStartupType/Test.MissingStartupType.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.MultipleEntryPoints/Test.MultipleEntryPoints.csproj
+++ b/samples/Configuration/Test.MultipleEntryPoints/Test.MultipleEntryPoints.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Configuration/Test.MultipleEntryPoints/Test.MultipleEntryPoints.csproj
+++ b/samples/Configuration/Test.MultipleEntryPoints/Test.MultipleEntryPoints.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.NoAsync/Test.NoAsync.csproj
+++ b/samples/Configuration/Test.NoAsync/Test.NoAsync.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Configuration/Test.NoAsync/Test.NoAsync.csproj
+++ b/samples/Configuration/Test.NoAsync/Test.NoAsync.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.NoStartupType/Test.NoStartupType.csproj
+++ b/samples/Configuration/Test.NoStartupType/Test.NoStartupType.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Configuration/Test.NoStartupType/Test.NoStartupType.csproj
+++ b/samples/Configuration/Test.NoStartupType/Test.NoStartupType.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.WrongStartupType/Test.WrongStartupType.csproj
+++ b/samples/Configuration/Test.WrongStartupType/Test.WrongStartupType.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Configuration/Test.WrongStartupType/Test.WrongStartupType.csproj
+++ b/samples/Configuration/Test.WrongStartupType/Test.WrongStartupType.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.WrongTestAssembly/Test.WrongTestAssembly.csproj
+++ b/samples/Configuration/Test.WrongTestAssembly/Test.WrongTestAssembly.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Configuration/Test.WrongTestAssembly/Test.WrongTestAssembly.csproj
+++ b/samples/Configuration/Test.WrongTestAssembly/Test.WrongTestAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.WrongWebAssembly/Test.WrongWebAssembly.csproj
+++ b/samples/Configuration/Test.WrongWebAssembly/Test.WrongWebAssembly.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/Configuration/Test.WrongWebAssembly/Test.WrongWebAssembly.csproj
+++ b/samples/Configuration/Test.WrongWebAssembly/Test.WrongWebAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/WebApplication.Controllers/WebApplication.Controllers.csproj
+++ b/samples/Configuration/WebApplication.Controllers/WebApplication.Controllers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/Configuration/WebApplication/Startup.cs
+++ b/samples/Configuration/WebApplication/Startup.cs
@@ -27,7 +27,7 @@
             services.AddTransient<IDataService, DataService>();
             services.AddTransient<IDateTimeService, DateTimeService>();
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            services.AddMvc();
         }
         
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/samples/Configuration/WebApplication/WebApplication.csproj
+++ b/samples/Configuration/WebApplication/WebApplication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/samples/Lite/Lite.Test/Lite.Test.csproj
+++ b/samples/Lite/Lite.Test/Lite.Test.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Lite/Lite.Test/Lite.Test.csproj
+++ b/samples/Lite/Lite.Test/Lite.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Lite/Lite.Web/Lite.Web.csproj
+++ b/samples/Lite/Lite.Web/Lite.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Lite/Lite.Web/Lite.Web.csproj
+++ b/samples/Lite/Lite.Web/Lite.Web.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/MusicStore/MusicStore.Test/MusicStore.Test.csproj
+++ b/samples/MusicStore/MusicStore.Test/MusicStore.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/MusicStore/MusicStore.Test/MusicStore.Test.csproj
+++ b/samples/MusicStore/MusicStore.Test/MusicStore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/MusicStore/MusicStore.Web/MusicStore.Web.csproj
+++ b/samples/MusicStore/MusicStore.Web/MusicStore.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>aspnet-MusicStore.Web-B1796332-CD47-4D99-85BC-7F98EA978F33</UserSecretsId>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>MusicStore</RootNamespace>

--- a/samples/MusicStore/MusicStore.Web/MusicStore.Web.csproj
+++ b/samples/MusicStore/MusicStore.Web/MusicStore.Web.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="5.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="5.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="5.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="5.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="5.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/NoStartup/NoStartup.Components/NoStartup.Components.csproj
+++ b/samples/NoStartup/NoStartup.Components/NoStartup.Components.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/samples/NoStartup/NoStartup.Controllers/NoStartup.Controllers.csproj
+++ b/samples/NoStartup/NoStartup.Controllers/NoStartup.Controllers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/samples/NoStartup/NoStartup.Test/NoStartup.Test.csproj
+++ b/samples/NoStartup/NoStartup.Test/NoStartup.Test.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>

--- a/samples/NoStartup/NoStartup.Test/NoStartup.Test.csproj
+++ b/samples/NoStartup/NoStartup.Test/NoStartup.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/WebStartup/WebStartup.Test/WebStartup.Test.csproj
+++ b/samples/WebStartup/WebStartup.Test/WebStartup.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/WebStartup/WebStartup.Test/WebStartup.Test.csproj
+++ b/samples/WebStartup/WebStartup.Test/WebStartup.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/WebStartup/WebStartup.Web/Startup.cs
+++ b/samples/WebStartup/WebStartup.Web/Startup.cs
@@ -25,7 +25,7 @@
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
             
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            services.AddMvc();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/WebStartup/WebStartup.Web/WebStartup.Web.csproj
+++ b/samples/WebStartup/WebStartup.Web/WebStartup.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/Server/TestWebServer.cs
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/Server/TestWebServer.cs
@@ -20,7 +20,8 @@
                 ApplicationName = ApplicationName,
                 EnvironmentName = ServerTestConfiguration.General.EnvironmentName,
                 ContentRootPath = AppContext.BaseDirectory,
-                WebRootFileProvider = new NullFileProvider()
+                WebRootFileProvider = new NullFileProvider(),
+                ContentRootFileProvider = new NullFileProvider()
             };
 
         internal static void ResetConfigurationAndAssemblies()

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/TestFramework.cs
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/TestFramework.cs
@@ -7,8 +7,8 @@
     public static class TestFramework
     {
         public const string TestFrameworkName = "MyTested.AspNetCore.Mvc";
-        public const string ReleaseDate = "2021-07-01";
-        public const string VersionPrefix = "5.0";
+        public const string ReleaseDate = "2022-01-01";
+        public const string VersionPrefix = "6.0";
 
         internal static void EnsureCorrectVersion(DependencyContext dependencyContext)
         {

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/MyTested.AspNetCore.Mvc.Abstractions.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/MyTested.AspNetCore.Mvc.Abstractions.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Abstractions</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/MyTested.AspNetCore.Mvc.Abstractions.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/MyTested.AspNetCore.Mvc.Abstractions.csproj
@@ -35,9 +35,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyTested.AspNetCore.Mvc.Authentication/MyTested.AspNetCore.Mvc.Authentication.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Authentication/MyTested.AspNetCore.Mvc.Authentication.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Authentication</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Caching/MyTested.AspNetCore.Mvc.Caching.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Caching/MyTested.AspNetCore.Mvc.Caching.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyTested.AspNetCore.Mvc.Caching/MyTested.AspNetCore.Mvc.Caching.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Caching/MyTested.AspNetCore.Mvc.Caching.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Caching</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Configuration/MyTested.AspNetCore.Mvc.Configuration.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Configuration/MyTested.AspNetCore.Mvc.Configuration.csproj
@@ -6,7 +6,7 @@
 		<AssemblyTitle>MyTested.AspNetCore.Mvc.Configuration</AssemblyTitle>
 		<VersionPrefix>5.0.0</VersionPrefix>
 		<Authors>Ivaylo Kenov</Authors>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Configuration/MyTested.AspNetCore.Mvc.Configuration.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Configuration/MyTested.AspNetCore.Mvc.Configuration.csproj
@@ -29,8 +29,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/MyTested.AspNetCore.Mvc.Controllers.ActionResults/MyTested.AspNetCore.Mvc.Controllers.ActionResults.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.ActionResults/MyTested.AspNetCore.Mvc.Controllers.ActionResults.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Controllers.ActionResults</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/MyTested.AspNetCore.Mvc.Controllers.Attributes.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/MyTested.AspNetCore.Mvc.Controllers.Attributes.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Controllers.Attributes</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Controllers.Views/MyTested.AspNetCore.Mvc.Controllers.Views.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Views/MyTested.AspNetCore.Mvc.Controllers.Views.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Controllers.Views</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Controllers/MyTested.AspNetCore.Mvc.Controllers.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Controllers/MyTested.AspNetCore.Mvc.Controllers.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Controllers</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Core/MyTested.AspNetCore.Mvc.Core.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Core/MyTested.AspNetCore.Mvc.Core.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Core</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.DataAnnotations/MyTested.AspNetCore.Mvc.DataAnnotations.csproj
+++ b/src/MyTested.AspNetCore.Mvc.DataAnnotations/MyTested.AspNetCore.Mvc.DataAnnotations.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.DataAnnotations</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.DependencyInjection/MyTested.AspNetCore.Mvc.DependencyInjection.csproj
+++ b/src/MyTested.AspNetCore.Mvc.DependencyInjection/MyTested.AspNetCore.Mvc.DependencyInjection.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.DependencyInjection</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/MyTested.AspNetCore.Mvc.EntityFrameworkCore.csproj
+++ b/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/MyTested.AspNetCore.Mvc.EntityFrameworkCore.csproj
@@ -33,8 +33,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/MyTested.AspNetCore.Mvc.EntityFrameworkCore.csproj
+++ b/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/MyTested.AspNetCore.Mvc.EntityFrameworkCore.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.EntityFrameworkCore</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/ServiceCollectionEntityFrameworkCoreExtensions.cs
+++ b/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/ServiceCollectionEntityFrameworkCoreExtensions.cs
@@ -8,6 +8,7 @@
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.Infrastructure;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
     using Utilities.Extensions;
 
     /// <summary>
@@ -75,7 +76,7 @@
 
             if (typeof(TDbContextService) != typeof(TDbContextImplementation))
             {
-                serviceCollection.AddScoped(s => s.GetRequiredService<TDbContextService>() as TDbContextImplementation);
+                serviceCollection.TryAddScoped(s => s.GetRequiredService<TDbContextService>() as TDbContextImplementation);
 
                 TestServiceProvider.SaveServiceLifetime<TDbContextImplementation>(ServiceLifetime.Scoped);
             }

--- a/src/MyTested.AspNetCore.Mvc.Helpers/MyTested.AspNetCore.Mvc.Helpers.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Helpers/MyTested.AspNetCore.Mvc.Helpers.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Helpers</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Http/MyTested.AspNetCore.Mvc.Http.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Http/MyTested.AspNetCore.Mvc.Http.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Http</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Lite/MyTested.AspNetCore.Mvc.Lite.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Lite/MyTested.AspNetCore.Mvc.Lite.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Lite</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ModelState/MyTested.AspNetCore.Mvc.ModelState.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ModelState/MyTested.AspNetCore.Mvc.ModelState.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ModelState</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Models/MyTested.AspNetCore.Mvc.Models.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Models/MyTested.AspNetCore.Mvc.Models.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Models</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Options/MyTested.AspNetCore.Mvc.Options.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Options/MyTested.AspNetCore.Mvc.Options.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Options</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Options/Plugins/OptionsTestPlugin.cs
+++ b/src/MyTested.AspNetCore.Mvc.Options/Plugins/OptionsTestPlugin.cs
@@ -7,12 +7,12 @@
     public class OptionsTestPlugin : IServiceRegistrationPlugin
     {
         private readonly Type defaultOptionsServiceType = typeof(IOptions<>);
-        private readonly Type defaultOptionsImplementationType = typeof(OptionsManager<>);
+        private readonly string defaultOptionsImplementationTypeName = "Microsoft.Extensions.Options.UnnamedOptionsManager`1";
         
         public Func<ServiceDescriptor, bool> ServiceSelectorPredicate
             => serviceDescriptor =>
                 serviceDescriptor.ServiceType == this.defaultOptionsServiceType &&
-                serviceDescriptor.ImplementationType == this.defaultOptionsImplementationType;
+                serviceDescriptor.ImplementationType.FullName == this.defaultOptionsImplementationTypeName;
 
         public Action<IServiceCollection> ServiceRegistrationDelegate 
             => serviceCollection => serviceCollection.ReplaceOptions();

--- a/src/MyTested.AspNetCore.Mvc.Pipeline/MyTested.AspNetCore.Mvc.Pipeline.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Pipeline/MyTested.AspNetCore.Mvc.Pipeline.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Pipeline</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Routing/MyTested.AspNetCore.Mvc.Routing.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Routing/MyTested.AspNetCore.Mvc.Routing.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Routing</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Session/MyTested.AspNetCore.Mvc.Session.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Session/MyTested.AspNetCore.Mvc.Session.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Session</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.TempData/MyTested.AspNetCore.Mvc.TempData.csproj
+++ b/src/MyTested.AspNetCore.Mvc.TempData/MyTested.AspNetCore.Mvc.TempData.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.TempData</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Universe/MyTested.AspNetCore.Mvc.Universe.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Universe/MyTested.AspNetCore.Mvc.Universe.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Universe</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ViewComponents.Attributes/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ViewComponents.Attributes/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ViewComponents.Attributes</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ViewComponents.Results/MyTested.AspNetCore.Mvc.ViewComponents.Results.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ViewComponents.Results/MyTested.AspNetCore.Mvc.ViewComponents.Results.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ViewComponents.Results</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ViewComponents/MyTested.AspNetCore.Mvc.ViewComponents.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ViewComponents/MyTested.AspNetCore.Mvc.ViewComponents.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ViewComponents</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ViewData/MyTested.AspNetCore.Mvc.ViewData.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ViewData/MyTested.AspNetCore.Mvc.ViewData.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ViewData</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ViewFeatures/MyTested.AspNetCore.Mvc.ViewFeatures.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ViewFeatures/MyTested.AspNetCore.Mvc.ViewFeatures.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ViewFeatures</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc/MyTested.AspNetCore.Mvc.csproj
+++ b/src/MyTested.AspNetCore.Mvc/MyTested.AspNetCore.Mvc.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>MyTested.AspNetCore.Mvc</AssemblyTitle>
     <VersionPrefix>5.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/MyTested.AspNetCore.Mvc.Abstractions.Test/MyTested.AspNetCore.Mvc.Abstractions.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Abstractions.Test/MyTested.AspNetCore.Mvc.Abstractions.Test.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Abstractions.Test/MyTested.AspNetCore.Mvc.Abstractions.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Abstractions.Test/MyTested.AspNetCore.Mvc.Abstractions.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Authentication.Test/MyTested.AspNetCore.Mvc.Authentication.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Authentication.Test/MyTested.AspNetCore.Mvc.Authentication.Test.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Authentication.Test/MyTested.AspNetCore.Mvc.Authentication.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Authentication.Test/MyTested.AspNetCore.Mvc.Authentication.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Caching.Test/MyTested.AspNetCore.Mvc.Caching.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Caching.Test/MyTested.AspNetCore.Mvc.Caching.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Caching.Test/MyTested.AspNetCore.Mvc.Caching.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Caching.Test/MyTested.AspNetCore.Mvc.Caching.Test.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Configuration.Test/MyTested.AspNetCore.Mvc.Configuration.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Configuration.Test/MyTested.AspNetCore.Mvc.Configuration.Test.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/MyTested.AspNetCore.Mvc.Configuration.Test/MyTested.AspNetCore.Mvc.Configuration.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Configuration.Test/MyTested.AspNetCore.Mvc.Configuration.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Test/MyTested.AspNetCore.Mvc.Controllers.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Test/MyTested.AspNetCore.Mvc.Controllers.Test.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Test/MyTested.AspNetCore.Mvc.Controllers.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Test/MyTested.AspNetCore.Mvc.Controllers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Views.Test/MyTested.AspNetCore.Mvc.Controllers.Views.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Views.Test/MyTested.AspNetCore.Mvc.Controllers.Views.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Views.Test/MyTested.AspNetCore.Mvc.Controllers.Views.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Views.Test/MyTested.AspNetCore.Mvc.Controllers.Views.Test.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.DataAnnotations.Test/MyTested.AspNetCore.Mvc.DataAnnotations.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.DataAnnotations.Test/MyTested.AspNetCore.Mvc.DataAnnotations.Test.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.DataAnnotations.Test/MyTested.AspNetCore.Mvc.DataAnnotations.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.DataAnnotations.Test/MyTested.AspNetCore.Mvc.DataAnnotations.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.DependencyInjection.Test/MyTested.AspNetCore.Mvc.DependencyInjection.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.DependencyInjection.Test/MyTested.AspNetCore.Mvc.DependencyInjection.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.DependencyInjection.Test/MyTested.AspNetCore.Mvc.DependencyInjection.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.DependencyInjection.Test/MyTested.AspNetCore.Mvc.DependencyInjection.Test.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test.csproj
@@ -29,13 +29,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Helpers.Test/MyTested.AspNetCore.Mvc.Helpers.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Helpers.Test/MyTested.AspNetCore.Mvc.Helpers.Test.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Helpers.Test/MyTested.AspNetCore.Mvc.Helpers.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Helpers.Test/MyTested.AspNetCore.Mvc.Helpers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Http.Test/MyTested.AspNetCore.Mvc.Http.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Http.Test/MyTested.AspNetCore.Mvc.Http.Test.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Http.Test/MyTested.AspNetCore.Mvc.Http.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Http.Test/MyTested.AspNetCore.Mvc.Http.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Licensing.Test/MyTested.AspNetCore.Mvc.Licensing.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Licensing.Test/MyTested.AspNetCore.Mvc.Licensing.Test.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Licensing.Test/MyTested.AspNetCore.Mvc.Licensing.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Licensing.Test/MyTested.AspNetCore.Mvc.Licensing.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>MyTested.AspNetCore.Mvc.Licensing.Test</AssemblyName>

--- a/test/MyTested.AspNetCore.Mvc.Lite.Test/MyTested.AspNetCore.Mvc.Lite.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Lite.Test/MyTested.AspNetCore.Mvc.Lite.Test.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Lite.Test/MyTested.AspNetCore.Mvc.Lite.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Lite.Test/MyTested.AspNetCore.Mvc.Lite.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ModelState.Test/MyTested.AspNetCore.Mvc.ModelState.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ModelState.Test/MyTested.AspNetCore.Mvc.ModelState.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ModelState.Test/MyTested.AspNetCore.Mvc.ModelState.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ModelState.Test/MyTested.AspNetCore.Mvc.ModelState.Test.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Models.Test/MyTested.AspNetCore.Mvc.Models.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Models.Test/MyTested.AspNetCore.Mvc.Models.Test.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Models.Test/MyTested.AspNetCore.Mvc.Models.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Models.Test/MyTested.AspNetCore.Mvc.Models.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Options.Test/MyTested.AspNetCore.Mvc.Options.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Options.Test/MyTested.AspNetCore.Mvc.Options.Test.csproj
@@ -28,13 +28,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Options.Test/MyTested.AspNetCore.Mvc.Options.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Options.Test/MyTested.AspNetCore.Mvc.Options.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Pipeline.Test/MyTested.AspNetCore.Mvc.Pipeline.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Pipeline.Test/MyTested.AspNetCore.Mvc.Pipeline.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Pipeline.Test/MyTested.AspNetCore.Mvc.Pipeline.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Pipeline.Test/MyTested.AspNetCore.Mvc.Pipeline.Test.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Routing.Test/MyTested.AspNetCore.Mvc.Routing.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Routing.Test/MyTested.AspNetCore.Mvc.Routing.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Routing.Test/MyTested.AspNetCore.Mvc.Routing.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Routing.Test/MyTested.AspNetCore.Mvc.Routing.Test.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Session.Test/MyTested.AspNetCore.Mvc.Session.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Session.Test/MyTested.AspNetCore.Mvc.Session.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Session.Test/MyTested.AspNetCore.Mvc.Session.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Session.Test/MyTested.AspNetCore.Mvc.Session.Test.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.TempData.Test/MyTested.AspNetCore.Mvc.TempData.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.TempData.Test/MyTested.AspNetCore.Mvc.TempData.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.TempData.Test/MyTested.AspNetCore.Mvc.TempData.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.TempData.Test/MyTested.AspNetCore.Mvc.TempData.Test.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Test.Setups/MyTested.AspNetCore.Mvc.Test.Setups.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Test.Setups/MyTested.AspNetCore.Mvc.Test.Setups.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 

--- a/test/MyTested.AspNetCore.Mvc.Test.Setups/MyTested.AspNetCore.Mvc.Test.Setups.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Test.Setups/MyTested.AspNetCore.Mvc.Test.Setups.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test.Setups</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Test.Setups/TestObjectFactory.cs
+++ b/test/MyTested.AspNetCore.Mvc.Test.Setups/TestObjectFactory.cs
@@ -108,7 +108,8 @@
         public static IOutputFormatter GetOutputFormatter() => new NewtonsoftJsonOutputFormatter(
             GetJsonSerializerSettings(), 
             ArrayPool<char>.Create(),
-            new MvcOptions());
+            new MvcOptions(),
+            null);
 
         public static Uri GetUri() => new Uri("http://somehost.com/someuri/1?query=Test");
 

--- a/test/MyTested.AspNetCore.Mvc.Test/MyTested.AspNetCore.Mvc.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Test/MyTested.AspNetCore.Mvc.Test.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.Test/MyTested.AspNetCore.Mvc.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Test/MyTested.AspNetCore.Mvc.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Universe.Test/MyTested.AspNetCore.Mvc.Universe.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Universe.Test/MyTested.AspNetCore.Mvc.Universe.Test.csproj
@@ -26,13 +26,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Universe.Test/MyTested.AspNetCore.Mvc.Universe.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Universe.Test/MyTested.AspNetCore.Mvc.Universe.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/MyTested.AspNetCore.Mvc.Versioning.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/MyTested.AspNetCore.Mvc.Versioning.Test.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/MyTested.AspNetCore.Mvc.Versioning.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/MyTested.AspNetCore.Mvc.Versioning.Test.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/MyTested.AspNetCore.Mvc.ViewComponents.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/MyTested.AspNetCore.Mvc.ViewComponents.Test.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/MyTested.AspNetCore.Mvc.ViewComponents.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/MyTested.AspNetCore.Mvc.ViewComponents.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ViewData.Test/MyTested.AspNetCore.Mvc.ViewData.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewData.Test/MyTested.AspNetCore.Mvc.ViewData.Test.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.ViewData.Test/MyTested.AspNetCore.Mvc.ViewData.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewData.Test/MyTested.AspNetCore.Mvc.ViewData.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ViewData.Test/PluginsTests/ViewDataTestPluginTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.ViewData.Test/PluginsTests/ViewDataTestPluginTests.cs
@@ -33,7 +33,7 @@
 
             testPlugin.DefaultServiceRegistrationDelegate(serviceCollection);
 
-            Assert.True(serviceCollection.Count == 160);        
+            Assert.True(serviceCollection.Count == 165);
         }
     }
 }

--- a/test/MyTested.AspNetCore.Mvc.ViewFeatures.Test/MyTested.AspNetCore.Mvc.ViewFeatures.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewFeatures.Test/MyTested.AspNetCore.Mvc.ViewFeatures.Test.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/MyTested.AspNetCore.Mvc.ViewFeatures.Test/MyTested.AspNetCore.Mvc.ViewFeatures.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewFeatures.Test/MyTested.AspNetCore.Mvc.ViewFeatures.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Revised all projects to build with .NET 6 and use AspNetCore v6 / EF Core v6 packages. Addressed issues within the codebase so that all unit tests pass.

About 100 unit tests were broken, including most within Options, EFCore, Samples, and Razor Compiler Services.

Compiler Services and all Samples were resolved by adding a NullFileProvider to the ContentRootFileProvider property within the host environment. Several of these tests were failing because `DefaultActionDescriptorCollectionProvider` was throwing a NullReferenceException when trying to access its own FileProvider, which defaults to the ContentRootFileProvider (which wasn't getting set).

EFCore tests were breaking on double-registered DbContextImplementation, resolved by changing to TryAddScope instead of AddScope. TryAddScope is a no-op if already registered.

Options was failing on the `OptionsTestPlugin` service selector; the implementation for IOptions<> changed from OptionsManager<> to the new UnnamedOptionsManager<> in AspNetCore 6. However, UnnamedOptionsManager is an internal class, so the plugin's service selector is doing a comparison on Type.FullName, rather than a strongly-typed comparison to Type.

Note: One project, `MyTested.AspNetCore.Mvc.Versioning`, remains at `Microsoft.AspNetCore.Mvc.Versioning` v5, since there is v6 release of `Microsoft.AspNetCore.Mvc.Versioning`.