### PR TITLE
Ignore Transaction Warnings

### DIFF
--- a/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/ServiceCollectionEntityFrameworkCoreExtensions.cs
+++ b/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/ServiceCollectionEntityFrameworkCoreExtensions.cs
@@ -6,6 +6,7 @@
     using Internal.EntityFrameworkCore;
     using Internal.Services;
     using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Diagnostics;
     using Microsoft.EntityFrameworkCore.Infrastructure;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -83,7 +84,9 @@
 
             serviceCollection.AddDbContext<TDbContextService, TDbContextImplementation>(opts =>
             {
-                opts.UseInMemoryDatabase(Guid.NewGuid().ToString());
+                opts
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                    .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning));
 
                 ((IDbContextOptionsBuilderInfrastructure)opts).AddOrUpdateExtension(new ScopedInMemoryOptionsExtension());
             });


### PR DESCRIPTION
This change will ignore the warnings coming from code that use EF core transactions as the In Memory Database does not support transactions.