### PR TITLE
Version 8.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,12 +13,11 @@ build:
   project: MyTested.AspNetCore.Mvc.sln
   verbosity: minimal
 test_script:
-- cmd: dotnet test "samples/MusicStore/MusicStore.Test/MusicStore.Test.csproj" --configuration Release --no-build
-- cmd: dotnet test "samples/Blog/Blog.Test/Blog.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "samples/ApplicationParts/ApplicationParts.Test/ApplicationParts.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "samples/Autofac/Autofac.AssemblyInit.Test/Autofac.AssemblyInit.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "samples/Autofac/Autofac.NoContainerBuilder.Test/Autofac.NoContainerBuilder.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "samples/Autofac/Autofac.Test/Autofac.Test.csproj" --configuration Release --no-build
+- cmd: dotnet test "samples/Blog/Blog.Test/Blog.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "samples/Configuration/Test.DifferentEnvironment/Test.DifferentEnvironment.csproj" --configuration Release --no-build
 - cmd: dotnet test "samples/Configuration/Test.ExplicitNoStartupType/Test.ExplicitNoStartupType.csproj" --configuration Release --no-build
 - cmd: dotnet test "samples/Configuration/Test.MissingStartupType/Test.MissingStartupType.csproj" --configuration Release --no-build
@@ -28,6 +27,7 @@ test_script:
 - cmd: dotnet test "samples/Configuration/Test.WrongStartupType/Test.WrongStartupType.csproj" --configuration Release --no-build
 - cmd: dotnet test "samples/Configuration/Test.WrongTestAssembly/Test.WrongTestAssembly.csproj" --configuration Release --no-build
 - cmd: dotnet test "samples/Configuration/Test.WrongWebAssembly/Test.WrongWebAssembly.csproj" --configuration Release --no-build
+- cmd: dotnet test "samples/MusicStore/MusicStore.Test/MusicStore.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "samples/NoStartup/NoStartup.Test/NoStartup.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "samples/WebStartup/WebStartup.Test/WebStartup.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.Abstractions.Test/MyTested.AspNetCore.Mvc.Abstractions.Test.csproj" --configuration Release --no-build
@@ -49,11 +49,14 @@ test_script:
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.Options.Test/MyTested.AspNetCore.Mvc.Options.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.Pipeline.Test/MyTested.AspNetCore.Mvc.Pipeline.Test.csproj" --configuration Release --no-build
+- cmd: dotnet test "test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.Routing.Test/MyTested.AspNetCore.Mvc.Routing.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.Session.Test/MyTested.AspNetCore.Mvc.Session.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.TempData.Test/MyTested.AspNetCore.Mvc.TempData.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.Test/MyTested.AspNetCore.Mvc.Test.csproj" --configuration Release --no-build
+- cmd: dotnet test "test/MyTested.AspNetCore.Mvc.Test.Setups/MyTested.AspNetCore.Mvc.Test.Setups.csproj" --configuration Release --no-build
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.Universe.Test/MyTested.AspNetCore.Mvc.Universe.Test.csproj" --configuration Release --no-build
+- cmd: dotnet test "test/MyTested.AspNetCore.Mvc.Versioning.Test/MyTested.AspNetCore.Mvc.Versioning.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test.csproj" --configuration Release --no-build
 - cmd: dotnet test "test/MyTested.AspNetCore.Mvc.ViewComponents.Test/MyTested.AspNetCore.Mvc.ViewComponents.Test.csproj" --configuration Release --no-build

--- a/plugins/MyTested.AspNetCore.Mvc.NewtonsoftJson/MyTested.AspNetCore.Mvc.NewtonsoftJson.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.NewtonsoftJson/MyTested.AspNetCore.Mvc.NewtonsoftJson.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC Newtonsoft JSON components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.NewtonsoftJson</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/plugins/MyTested.AspNetCore.Mvc.NewtonsoftJson/MyTested.AspNetCore.Mvc.NewtonsoftJson.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.NewtonsoftJson/MyTested.AspNetCore.Mvc.NewtonsoftJson.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
   </ItemGroup>
     
   <ItemGroup>

--- a/plugins/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC razor runtime compilation components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/plugins/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/MyTested.AspNetCore.Mvc.Versioning.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/MyTested.AspNetCore.Mvc.Versioning.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
   </ItemGroup>
     
   <ItemGroup>

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/MyTested.AspNetCore.Mvc.Versioning.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/MyTested.AspNetCore.Mvc.Versioning.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC versioning components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Versioning</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/samples/ApplicationParts/ApplicationParts.Controllers/ApplicationParts.Controllers.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Controllers/ApplicationParts.Controllers.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/ApplicationParts/ApplicationParts.Controllers/ApplicationParts.Controllers.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Controllers/ApplicationParts.Controllers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>ApplicationParts.Controllers</AssemblyName>
     <PackageId>ApplicationParts.Controllers</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/samples/ApplicationParts/ApplicationParts.Models/ApplicationParts.Models.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Models/ApplicationParts.Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>ApplicationParts.Models</AssemblyName>
     <PackageId>ApplicationParts.Models</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/samples/ApplicationParts/ApplicationParts.Models/ApplicationParts.Models.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Models/ApplicationParts.Models.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/ApplicationParts/ApplicationParts.Services/ApplicationParts.Services.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Services/ApplicationParts.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>ApplicationParts.Services</AssemblyName>
     <PackageId>ApplicationParts.Services</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/samples/ApplicationParts/ApplicationParts.Test/ApplicationParts.Test.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Test/ApplicationParts.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/ApplicationParts/ApplicationParts.Test/ApplicationParts.Test.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Test/ApplicationParts.Test.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/ApplicationParts/ApplicationParts.Web/ApplicationParts.Web.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Web/ApplicationParts.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyName>ApplicationParts.Web</AssemblyName>
 		<UserSecretsId>aspnet-ApplicationParts.Web-c273a372-79ef-490d-b0e1-a7fb8f2dacc7</UserSecretsId>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/samples/ApplicationParts/ApplicationParts.Web/ApplicationParts.Web.csproj
+++ b/samples/ApplicationParts/ApplicationParts.Web/ApplicationParts.Web.csproj
@@ -18,16 +18,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/samples/Autofac/Autofac.AssemblyInit.Test/Autofac.AssemblyInit.Test.csproj
+++ b/samples/Autofac/Autofac.AssemblyInit.Test/Autofac.AssemblyInit.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/samples/Autofac/Autofac.AssemblyInit.Test/Autofac.AssemblyInit.Test.csproj
+++ b/samples/Autofac/Autofac.AssemblyInit.Test/Autofac.AssemblyInit.Test.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Autofac/Autofac.NoContainerBuilder.Test/Autofac.NoContainerBuilder.Test.csproj
+++ b/samples/Autofac/Autofac.NoContainerBuilder.Test/Autofac.NoContainerBuilder.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Autofac/Autofac.NoContainerBuilder.Test/Autofac.NoContainerBuilder.Test.csproj
+++ b/samples/Autofac/Autofac.NoContainerBuilder.Test/Autofac.NoContainerBuilder.Test.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Autofac/Autofac.NoContainerBuilder.Web/Autofac.NoContainerBuilder.Web.csproj
+++ b/samples/Autofac/Autofac.NoContainerBuilder.Web/Autofac.NoContainerBuilder.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/samples/Autofac/Autofac.NoContainerBuilder.Web/Models/ErrorViewModel.cs
+++ b/samples/Autofac/Autofac.NoContainerBuilder.Web/Models/ErrorViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Autofac.NoContainerBuilder.Web.Models
 {
     public class ErrorViewModel

--- a/samples/Autofac/Autofac.NoContainerBuilder.Web/Startup.cs
+++ b/samples/Autofac/Autofac.NoContainerBuilder.Web/Startup.cs
@@ -5,7 +5,6 @@
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;

--- a/samples/Autofac/Autofac.Test/Autofac.Test.csproj
+++ b/samples/Autofac/Autofac.Test/Autofac.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Autofac/Autofac.Test/Autofac.Test.csproj
+++ b/samples/Autofac/Autofac.Test/Autofac.Test.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Autofac/Autofac.Web/Autofac.Web.csproj
+++ b/samples/Autofac/Autofac.Web/Autofac.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/samples/Autofac/Autofac.Web/Models/ErrorViewModel.cs
+++ b/samples/Autofac/Autofac.Web/Models/ErrorViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Autofac.Web.Models
 {
     public class ErrorViewModel

--- a/samples/Autofac/Autofac.Web/Startup.cs
+++ b/samples/Autofac/Autofac.Web/Startup.cs
@@ -3,7 +3,6 @@
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;

--- a/samples/Blog/Blog.Controllers/Blog.Controllers.csproj
+++ b/samples/Blog/Blog.Controllers/Blog.Controllers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/Blog/Blog.Data/Blog.Data.csproj
+++ b/samples/Blog/Blog.Data/Blog.Data.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Blog/Blog.Data/Blog.Data.csproj
+++ b/samples/Blog/Blog.Data/Blog.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/Blog/Blog.Services/Blog.Services.csproj
+++ b/samples/Blog/Blog.Services/Blog.Services.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Blog/Blog.Services/Blog.Services.csproj
+++ b/samples/Blog/Blog.Services/Blog.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/Blog/Blog.Test/Blog.Test.csproj
+++ b/samples/Blog/Blog.Test/Blog.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Blog/Blog.Test/Blog.Test.csproj
+++ b/samples/Blog/Blog.Test/Blog.Test.csproj
@@ -12,11 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="Shouldly" Version="4.1.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Blog/Blog.Web/Blog.Web.csproj
+++ b/samples/Blog/Blog.Web/Blog.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>aspnet-Blog.Web-6757ED6F-7F48-4961-917B-ADA8F5DEAFB4</UserSecretsId>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/samples/Blog/Blog.Web/Blog.Web.csproj
+++ b/samples/Blog/Blog.Web/Blog.Web.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Blog/Blog.Web/Startup.cs
+++ b/samples/Blog/Blog.Web/Startup.cs
@@ -1,6 +1,5 @@
 ﻿namespace Blog.Web
 {
-    using AutoMapper;
     using Controllers;
     using Data;
     using Data.Models;
@@ -9,7 +8,6 @@
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Identity;
-    using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;

--- a/samples/Configuration/Common/AdditionalEntryPoint.csproj
+++ b/samples/Configuration/Common/AdditionalEntryPoint.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
 </Project>

--- a/samples/Configuration/Common/AdditionalEntryPoint.csproj
+++ b/samples/Configuration/Common/AdditionalEntryPoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsTestProject>false</IsTestProject>
     <IsPackable>false</IsPackable>

--- a/samples/Configuration/Test.DifferentEnvironment/Test.DifferentEnvironment.csproj
+++ b/samples/Configuration/Test.DifferentEnvironment/Test.DifferentEnvironment.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.DifferentEnvironment/Test.DifferentEnvironment.csproj
+++ b/samples/Configuration/Test.DifferentEnvironment/Test.DifferentEnvironment.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Configuration/Test.ExplicitNoStartupType/Test.ExplicitNoStartupType.csproj
+++ b/samples/Configuration/Test.ExplicitNoStartupType/Test.ExplicitNoStartupType.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.ExplicitNoStartupType/Test.ExplicitNoStartupType.csproj
+++ b/samples/Configuration/Test.ExplicitNoStartupType/Test.ExplicitNoStartupType.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Configuration/Test.MissingStartupType/Test.MissingStartupType.csproj
+++ b/samples/Configuration/Test.MissingStartupType/Test.MissingStartupType.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.MissingStartupType/Test.MissingStartupType.csproj
+++ b/samples/Configuration/Test.MissingStartupType/Test.MissingStartupType.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Configuration/Test.MultipleEntryPoints/Test.MultipleEntryPoints.csproj
+++ b/samples/Configuration/Test.MultipleEntryPoints/Test.MultipleEntryPoints.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.MultipleEntryPoints/Test.MultipleEntryPoints.csproj
+++ b/samples/Configuration/Test.MultipleEntryPoints/Test.MultipleEntryPoints.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Configuration/Test.NoAsync/Test.NoAsync.csproj
+++ b/samples/Configuration/Test.NoAsync/Test.NoAsync.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.NoAsync/Test.NoAsync.csproj
+++ b/samples/Configuration/Test.NoAsync/Test.NoAsync.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Configuration/Test.NoStartupType/Test.NoStartupType.csproj
+++ b/samples/Configuration/Test.NoStartupType/Test.NoStartupType.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.NoStartupType/Test.NoStartupType.csproj
+++ b/samples/Configuration/Test.NoStartupType/Test.NoStartupType.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Configuration/Test.WrongStartupType/Test.WrongStartupType.csproj
+++ b/samples/Configuration/Test.WrongStartupType/Test.WrongStartupType.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.WrongStartupType/Test.WrongStartupType.csproj
+++ b/samples/Configuration/Test.WrongStartupType/Test.WrongStartupType.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Configuration/Test.WrongTestAssembly/Test.WrongTestAssembly.csproj
+++ b/samples/Configuration/Test.WrongTestAssembly/Test.WrongTestAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.WrongTestAssembly/Test.WrongTestAssembly.csproj
+++ b/samples/Configuration/Test.WrongTestAssembly/Test.WrongTestAssembly.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Configuration/Test.WrongWebAssembly/Test.WrongWebAssembly.csproj
+++ b/samples/Configuration/Test.WrongWebAssembly/Test.WrongWebAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/Configuration/Test.WrongWebAssembly/Test.WrongWebAssembly.csproj
+++ b/samples/Configuration/Test.WrongWebAssembly/Test.WrongWebAssembly.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Configuration/WebApplication.Controllers/WebApplication.Controllers.csproj
+++ b/samples/Configuration/WebApplication.Controllers/WebApplication.Controllers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/Configuration/WebApplication.Services/WebApplication.Services.csproj
+++ b/samples/Configuration/WebApplication.Services/WebApplication.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/Configuration/WebApplication/Startup.cs
+++ b/samples/Configuration/WebApplication/Startup.cs
@@ -3,7 +3,6 @@
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;

--- a/samples/Configuration/WebApplication/WebApplication.csproj
+++ b/samples/Configuration/WebApplication/WebApplication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/samples/MusicStore/MusicStore.Test/MusicStore.Test.csproj
+++ b/samples/MusicStore/MusicStore.Test/MusicStore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/MusicStore/MusicStore.Test/MusicStore.Test.csproj
+++ b/samples/MusicStore/MusicStore.Test/MusicStore.Test.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MusicStore/MusicStore.Web/MusicStore.Web.csproj
+++ b/samples/MusicStore/MusicStore.Web/MusicStore.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>aspnet-MusicStore.Web-B1796332-CD47-4D99-85BC-7F98EA978F33</UserSecretsId>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>MusicStore</RootNamespace>

--- a/samples/MusicStore/MusicStore.Web/MusicStore.Web.csproj
+++ b/samples/MusicStore/MusicStore.Web/MusicStore.Web.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/NoStartup/NoStartup.Components/NoStartup.Components.csproj
+++ b/samples/NoStartup/NoStartup.Components/NoStartup.Components.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/samples/NoStartup/NoStartup.Controllers/NoStartup.Controllers.csproj
+++ b/samples/NoStartup/NoStartup.Controllers/NoStartup.Controllers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/samples/NoStartup/NoStartup.Services/NoStartup.Services.csproj
+++ b/samples/NoStartup/NoStartup.Services/NoStartup.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/samples/NoStartup/NoStartup.Test/NoStartup.Test.csproj
+++ b/samples/NoStartup/NoStartup.Test/NoStartup.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/NoStartup/NoStartup.Test/NoStartup.Test.csproj
+++ b/samples/NoStartup/NoStartup.Test/NoStartup.Test.csproj
@@ -24,9 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/WebStartup/WebStartup.Test/WebStartup.Test.csproj
+++ b/samples/WebStartup/WebStartup.Test/WebStartup.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/WebStartup/WebStartup.Test/WebStartup.Test.csproj
+++ b/samples/WebStartup/WebStartup.Test/WebStartup.Test.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/WebStartup/WebStartup.Web/Startup.cs
+++ b/samples/WebStartup/WebStartup.Web/Startup.cs
@@ -3,7 +3,6 @@
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;

--- a/samples/WebStartup/WebStartup.Web/WebStartup.Web.csproj
+++ b/samples/WebStartup/WebStartup.Web/WebStartup.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/Builders/Authentication/BaseClaimsPrincipalUserBuilder.cs
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/Builders/Authentication/BaseClaimsPrincipalUserBuilder.cs
@@ -1,6 +1,5 @@
 ﻿namespace MyTested.AspNetCore.Mvc.Builders.Authentication
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Security.Claims;

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/Application/ApplicationBuilderMock.cs
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/Application/ApplicationBuilderMock.cs
@@ -128,12 +128,10 @@
 
         private void ExtractEndpointRoutes(Func<RequestDelegate, RequestDelegate> middleware)
         {
-            var stateTypeField = middleware.GetTargetField("state");
-            var stateType = stateTypeField?.GetValue(middleware.Target);
+            var middlewareTypeField = middleware.GetTargetField("_middleware");
+            var middlewareType = middlewareTypeField?.GetValue(middleware.Target);
 
-            var middlewareTypeProperty = stateType?.GetType().GetProperty("Middleware");
-
-            if (middlewareTypeProperty?.GetValue(stateType) is not Type { Name: "EndpointMiddleware" })
+            if (middlewareType is not Type { Name: "EndpointMiddleware" })
             {
                 return;
             }
@@ -220,7 +218,7 @@
 
         private void ExtractLegacyRoutes(Func<RequestDelegate, RequestDelegate> middleware)
         {
-            var middlewareArguments = middleware.GetTargetField("args");
+            var middlewareArguments = middleware.GetTargetField("_args");
 
             if (middlewareArguments?.GetValue(middleware.Target) is object[] argumentsValues)
             {

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/Application/ApplicationBuilderMock.cs
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/Application/ApplicationBuilderMock.cs
@@ -103,7 +103,7 @@
             RequestDelegate app = context =>
             {
                 context.Response.StatusCode = 404;
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             };
 
             foreach (var component in this.components.Reverse())

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/Application/TestApplicationRouter.cs
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/Application/TestApplicationRouter.cs
@@ -6,7 +6,6 @@
     using Routing;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Routing;
     using Microsoft.Extensions.DependencyInjection;
     using Utilities.Extensions;

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/TestFramework.cs
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/Internal/TestFramework.cs
@@ -7,8 +7,8 @@
     public static class TestFramework
     {
         public const string TestFrameworkName = "MyTested.AspNetCore.Mvc";
-        public const string ReleaseDate = "2023-01-01";
-        public const string VersionPrefix = "7.0";
+        public const string ReleaseDate = "2023-11-19";
+        public const string VersionPrefix = "8.0";
 
         internal static void EnsureCorrectVersion(DependencyContext dependencyContext)
         {

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/MyTested.AspNetCore.Mvc.Abstractions.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/MyTested.AspNetCore.Mvc.Abstractions.csproj
@@ -35,9 +35,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/MyTested.AspNetCore.Mvc.Abstractions.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/MyTested.AspNetCore.Mvc.Abstractions.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC common abstractions and interfaces.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Abstractions</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Abstractions/Utilities/Extensions/ActionTestContextExtensions.cs
+++ b/src/MyTested.AspNetCore.Mvc.Abstractions/Utilities/Extensions/ActionTestContextExtensions.cs
@@ -1,7 +1,6 @@
 ﻿namespace MyTested.AspNetCore.Mvc.Utilities.Extensions
 {
     using System;
-    using System.Threading.Tasks;
     using Internal.TestContexts;
     using Microsoft.AspNetCore.Mvc;
 

--- a/src/MyTested.AspNetCore.Mvc.Authentication/MyTested.AspNetCore.Mvc.Authentication.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Authentication/MyTested.AspNetCore.Mvc.Authentication.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC authentication components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Authentication</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Caching/Builders/Data/MemoryCache/WithMemoryCache/WithMemoryCacheBuilder.cs
+++ b/src/MyTested.AspNetCore.Mvc.Caching/Builders/Data/MemoryCache/WithMemoryCache/WithMemoryCacheBuilder.cs
@@ -6,7 +6,6 @@
     using Contracts.Data.MemoryCache;
     using Data.MemoryCache;
     using Microsoft.Extensions.Caching.Memory;
-    using Microsoft.Extensions.DependencyInjection;
     using Utilities.Extensions;
 
     /// <inheritdoc />

--- a/src/MyTested.AspNetCore.Mvc.Caching/MyTested.AspNetCore.Mvc.Caching.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Caching/MyTested.AspNetCore.Mvc.Caching.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC caching components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Caching</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Caching/MyTested.AspNetCore.Mvc.Caching.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Caching/MyTested.AspNetCore.Mvc.Caching.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyTested.AspNetCore.Mvc.Configuration/MyTested.AspNetCore.Mvc.Configuration.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Configuration/MyTested.AspNetCore.Mvc.Configuration.csproj
@@ -1,40 +1,41 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <Description>My Tested ASP.NET Core MVC configuration components.</Description>
-        <Copyright>2015-2023 Ivaylo Kenov</Copyright>
-        <AssemblyTitle>MyTested.AspNetCore.Mvc.Configuration</AssemblyTitle>
-        <VersionPrefix>7.0.0</VersionPrefix>
-        <Authors>Ivaylo Kenov</Authors>
-        <TargetFramework>net7.0</TargetFramework>
-        <NoWarn>$(NoWarn);CS1591</NoWarn>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <AssemblyName>MyTested.AspNetCore.Mvc.Configuration</AssemblyName>
-        <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>
-        <SignAssembly>true</SignAssembly>
-        <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-        <PackageId>MyTested.AspNetCore.Mvc.Configuration</PackageId>
-        <PackageTags>aspnetcore;aspnetcoremvc;testing;unit;tests;fluent;testing;framework;asp;net;core;mvc;test;mymvc;mytested</PackageTags>
-        <PackageIcon>nuget-logo.png</PackageIcon>
-        <PackageProjectUrl>https://mytestedasp.net/</PackageProjectUrl>
-        <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/ivaylokenov/MyTested.AspNetCore.Mvc</RepositoryUrl>
-        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-        <RootNamespace>MyTested.AspNetCore.Mvc</RootNamespace>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    </PropertyGroup>
+  <PropertyGroup>
+    <Description>My Tested ASP.NET Core MVC configuration components.</Description>
+    <Copyright>2015-2023 Ivaylo Kenov</Copyright>
+    <AssemblyTitle>MyTested.AspNetCore.Mvc.Configuration</AssemblyTitle>
+    <VersionPrefix>8.0.0</VersionPrefix>
+    <Authors>Ivaylo Kenov</Authors>
+    <TargetFramework>net8.0</TargetFramework>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>MyTested.AspNetCore.Mvc.Configuration</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PackageId>MyTested.AspNetCore.Mvc.Configuration</PackageId>
+    <PackageTags>aspnetcore;aspnetcoremvc;testing;unit;tests;fluent;testing;framework;asp;net;core;mvc;test;mymvc;mytested</PackageTags>
+    <PackageIcon>nuget-logo.png</PackageIcon>
+    <PackageProjectUrl>https://mytestedasp.net/</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/ivaylokenov/MyTested.AspNetCore.Mvc</RepositoryUrl>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <RootNamespace>MyTested.AspNetCore.Mvc</RootNamespace>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.1" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.1" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <None Include="../../LICENSE" Pack="true" PackagePath="" />
-        <None Include="../../tools/nuget-logo.png" Pack="true" PackagePath="" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Include="../../LICENSE" Pack="true" PackagePath="" />
+    <None Include="../../tools/nuget-logo.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
 </Project>

--- a/src/MyTested.AspNetCore.Mvc.Configuration/MyTested.AspNetCore.Mvc.Configuration.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Configuration/MyTested.AspNetCore.Mvc.Configuration.csproj
@@ -29,8 +29,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyTested.AspNetCore.Mvc.Controllers.ActionResults/MyTested.AspNetCore.Mvc.Controllers.ActionResults.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.ActionResults/MyTested.AspNetCore.Mvc.Controllers.ActionResults.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC controller action result components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Controllers.ActionResults</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/Builders/Attributes/MiddlewareFilterAttributeTestBuilder.cs
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/Builders/Attributes/MiddlewareFilterAttributeTestBuilder.cs
@@ -4,7 +4,6 @@
     using Microsoft.AspNetCore.Mvc;
     using Contracts.Attributes;
     using Internal.TestContexts;
-    using Utilities;
 
     /// <summary>
     /// Used for testing <see cref="MiddlewareFilterAttribute"/>.

--- a/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/MyTested.AspNetCore.Mvc.Controllers.Attributes.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Attributes/MyTested.AspNetCore.Mvc.Controllers.Attributes.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC controller attribute components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Controllers.Attributes</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC controller view action result components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults/ViewComponentTestBuilderExtensions.cs
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults/ViewComponentTestBuilderExtensions.cs
@@ -6,7 +6,6 @@
     using Builders.Contracts.ActionResults.View;
     using Exceptions;
     using Microsoft.AspNetCore.Routing;
-    using Utilities;
     using Utilities.Extensions;
     using Utilities.Validators;
 

--- a/src/MyTested.AspNetCore.Mvc.Controllers.Views/Builders/ActionResults/View/BaseTestBuilderWithViewFeatureResult.cs
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Views/Builders/ActionResults/View/BaseTestBuilderWithViewFeatureResult.cs
@@ -1,6 +1,5 @@
 ﻿namespace MyTested.AspNetCore.Mvc.Builders.ActionResults.View
 {
-    using System;
     using Builders.Base;
     using Contracts.Base;
     using Internal.TestContexts;

--- a/src/MyTested.AspNetCore.Mvc.Controllers.Views/MyTested.AspNetCore.Mvc.Controllers.Views.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Controllers.Views/MyTested.AspNetCore.Mvc.Controllers.Views.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC controller view assertion methods.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Controllers.Views</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Controllers/Builders/Actions/ShouldReturn/ShouldReturnUnprocessableEntity.cs
+++ b/src/MyTested.AspNetCore.Mvc.Controllers/Builders/Actions/ShouldReturn/ShouldReturnUnprocessableEntity.cs
@@ -1,9 +1,7 @@
 ﻿namespace MyTested.AspNetCore.Mvc.Builders.Actions.ShouldReturn
 {
     using System;
-    using ActionResults.BadRequest;
     using ActionResults.UnprocessableEntity;
-    using Contracts.ActionResults.BadRequest;
     using Contracts.ActionResults.UnprocessableEntity;
     using Contracts.And;
     using Microsoft.AspNetCore.Mvc;

--- a/src/MyTested.AspNetCore.Mvc.Controllers/MyTested.AspNetCore.Mvc.Controllers.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Controllers/MyTested.AspNetCore.Mvc.Controllers.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC controller components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Controllers</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Core/MyTested.AspNetCore.Mvc.Core.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Core/MyTested.AspNetCore.Mvc.Core.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC core components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Core</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.DataAnnotations/BaseTestBuilderWithErrorResultDataAnnotationsExtensions.cs
+++ b/src/MyTested.AspNetCore.Mvc.DataAnnotations/BaseTestBuilderWithErrorResultDataAnnotationsExtensions.cs
@@ -4,7 +4,6 @@
     using Builders.Contracts.Base;
     using Builders.Contracts.Models;
     using Builders.Models;
-    using Exceptions;
     using Internal.Contracts.ActionResults;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/src/MyTested.AspNetCore.Mvc.DataAnnotations/MyTested.AspNetCore.Mvc.DataAnnotations.csproj
+++ b/src/MyTested.AspNetCore.Mvc.DataAnnotations/MyTested.AspNetCore.Mvc.DataAnnotations.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC data annotations components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.DataAnnotations</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.DependencyInjection/MyTested.AspNetCore.Mvc.DependencyInjection.csproj
+++ b/src/MyTested.AspNetCore.Mvc.DependencyInjection/MyTested.AspNetCore.Mvc.DependencyInjection.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC dependency injection components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.DependencyInjection</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/MyTested.AspNetCore.Mvc.EntityFrameworkCore.csproj
+++ b/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/MyTested.AspNetCore.Mvc.EntityFrameworkCore.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC Entity Framework Core components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.EntityFrameworkCore</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/MyTested.AspNetCore.Mvc.EntityFrameworkCore.csproj
+++ b/src/MyTested.AspNetCore.Mvc.EntityFrameworkCore/MyTested.AspNetCore.Mvc.EntityFrameworkCore.csproj
@@ -33,8 +33,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyTested.AspNetCore.Mvc.Helpers/MyTested.AspNetCore.Mvc.Helpers.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Helpers/MyTested.AspNetCore.Mvc.Helpers.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC helper components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Helpers</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Http/Builders/Http/HttpRequestBuilder.cs
+++ b/src/MyTested.AspNetCore.Mvc.Http/Builders/Http/HttpRequestBuilder.cs
@@ -205,7 +205,7 @@
         /// <inheritdoc />
         public IAndHttpRequestBuilder WithHeader(string name, string value)
         {
-            this.request.Headers.Add(name, value);
+            this.request.Headers.Append(name, value);
             return this;
         }
 
@@ -220,7 +220,7 @@
         /// <inheritdoc />
         public IAndHttpRequestBuilder WithHeader(string name, StringValues values)
         {
-            this.request.Headers.Add(name, values);
+            this.request.Headers.Append(name, values);
             return this;
         }
 

--- a/src/MyTested.AspNetCore.Mvc.Http/MyTested.AspNetCore.Mvc.Http.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Http/MyTested.AspNetCore.Mvc.Http.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC HTTP components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Http</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ModelState/MyTested.AspNetCore.Mvc.ModelState.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ModelState/MyTested.AspNetCore.Mvc.ModelState.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC model state components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ModelState</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Models/MyTested.AspNetCore.Mvc.Models.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Models/MyTested.AspNetCore.Mvc.Models.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC model components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Models</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Options/MyTested.AspNetCore.Mvc.Options.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Options/MyTested.AspNetCore.Mvc.Options.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC configuration options components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Options</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Pipeline/MyTested.AspNetCore.Mvc.Pipeline.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Pipeline/MyTested.AspNetCore.Mvc.Pipeline.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC pipeline components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Pipeline</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Routing/MyTested.AspNetCore.Mvc.Routing.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Routing/MyTested.AspNetCore.Mvc.Routing.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC routing components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Routing</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Session/MyTested.AspNetCore.Mvc.Session.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Session/MyTested.AspNetCore.Mvc.Session.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC session middleware components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Session</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.TempData/MyTested.AspNetCore.Mvc.TempData.csproj
+++ b/src/MyTested.AspNetCore.Mvc.TempData/MyTested.AspNetCore.Mvc.TempData.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC temporary data components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.TempData</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.Universe/MyTested.AspNetCore.Mvc.Universe.csproj
+++ b/src/MyTested.AspNetCore.Mvc.Universe/MyTested.AspNetCore.Mvc.Universe.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC is a powerful testing library providing easy fluent interface to test the ASP.NET Core MVC framework.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.Universe</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ViewComponents.Attributes/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ViewComponents.Attributes/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC view component attribute assertion methods.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ViewComponents.Attributes</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ViewComponents.Results/MyTested.AspNetCore.Mvc.ViewComponents.Results.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ViewComponents.Results/MyTested.AspNetCore.Mvc.ViewComponents.Results.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC view component result assertion methods.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ViewComponents.Results</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ViewComponents/MyTested.AspNetCore.Mvc.ViewComponents.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ViewComponents/MyTested.AspNetCore.Mvc.ViewComponents.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC view components assertion methods.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ViewComponents</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ViewData/MyTested.AspNetCore.Mvc.ViewData.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ViewData/MyTested.AspNetCore.Mvc.ViewData.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC view data components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ViewData</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc.ViewFeatures/MyTested.AspNetCore.Mvc.ViewFeatures.csproj
+++ b/src/MyTested.AspNetCore.Mvc.ViewFeatures/MyTested.AspNetCore.Mvc.ViewFeatures.csproj
@@ -4,9 +4,9 @@
     <Description>My Tested ASP.NET Core MVC view features components.</Description>
     <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc.ViewFeatures</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc/MyTested.AspNetCore.Mvc.csproj
+++ b/src/MyTested.AspNetCore.Mvc/MyTested.AspNetCore.Mvc.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <Description>My Tested ASP.NET Core MVC is a powerful testing library providing easy fluent interface to test the ASP.NET Core MVC framework.</Description>
-    <Copyright>2015-2023 Ivaylo Kenov</Copyright>
+    <Copyright>2015-2024 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc</AssemblyTitle>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MyTested.AspNetCore.Mvc/MyTested.AspNetCore.Mvc.csproj
+++ b/src/MyTested.AspNetCore.Mvc/MyTested.AspNetCore.Mvc.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>My Tested ASP.NET Core MVC is a powerful testing library providing easy fluent interface to test the ASP.NET Core MVC framework.</Description>
-    <Copyright>2015-2024 Ivaylo Kenov</Copyright>
+    <Copyright>2015-2023 Ivaylo Kenov</Copyright>
     <AssemblyTitle>MyTested.AspNetCore.Mvc</AssemblyTitle>
     <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Ivaylo Kenov</Authors>

--- a/test/MyTested.AspNetCore.Mvc.Abstractions.Test/MyTested.AspNetCore.Mvc.Abstractions.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Abstractions.Test/MyTested.AspNetCore.Mvc.Abstractions.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Abstractions.Test/MyTested.AspNetCore.Mvc.Abstractions.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Abstractions.Test/MyTested.AspNetCore.Mvc.Abstractions.Test.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Authentication.Test/MyTested.AspNetCore.Mvc.Authentication.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Authentication.Test/MyTested.AspNetCore.Mvc.Authentication.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Authentication.Test/MyTested.AspNetCore.Mvc.Authentication.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Authentication.Test/MyTested.AspNetCore.Mvc.Authentication.Test.csproj
@@ -28,9 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Caching.Test/MyTested.AspNetCore.Mvc.Caching.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Caching.Test/MyTested.AspNetCore.Mvc.Caching.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Caching.Test/MyTested.AspNetCore.Mvc.Caching.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Caching.Test/MyTested.AspNetCore.Mvc.Caching.Test.csproj
@@ -29,9 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Caching.Test/ServicesTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Caching.Test/ServicesTests.cs
@@ -1,4 +1,6 @@
-﻿namespace MyTested.AspNetCore.Mvc.Test
+﻿#pragma warning disable xUnit1030
+#pragma warning disable xUnit1031
+namespace MyTested.AspNetCore.Mvc.Test
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;

--- a/test/MyTested.AspNetCore.Mvc.Caching.Test/ServicesTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Caching.Test/ServicesTests.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable xUnit1030
-#pragma warning disable xUnit1031
-namespace MyTested.AspNetCore.Mvc.Test
+﻿namespace MyTested.AspNetCore.Mvc.Test
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
@@ -54,7 +52,7 @@ namespace MyTested.AspNetCore.Mvc.Test
 
             MyApplication.StartsFrom<DefaultStartup>();
         }
-        
+
         [Fact]
         public void MockMemoryCacheShouldBeDifferentForEveryViewComponentCallSynchronously()
         {
@@ -150,9 +148,9 @@ namespace MyTested.AspNetCore.Mvc.Test
         }
 
         [Fact]
-        public void MockMemoryCacheShouldBeDifferentForEveryCallAsynchronously()
+        public async Task MockMemoryCacheShouldBeDifferentForEveryCallAsynchronously()
         {
-            Task
+            await Task
                 .Run(async () =>
                 {
                     MyApplication
@@ -216,10 +214,7 @@ namespace MyTested.AspNetCore.Mvc.Test
                     Assert.Equal("fifth", fifthValue);
 
                     MyApplication.StartsFrom<DefaultStartup>();
-                })
-                .ConfigureAwait(false)
-                .GetAwaiter()
-                .GetResult();
+                });
         }
 
         [Fact]
@@ -244,7 +239,7 @@ namespace MyTested.AspNetCore.Mvc.Test
             // second call should not have cache entries
             MyController<MvcController>
                 .Instance()
-                .WithDistributedCache(cache => cache.WithEntry("test", new byte[] { 127, 127,127 }))
+                .WithDistributedCache(cache => cache.WithEntry("test", new byte[] { 127, 127, 127 }))
                 .Calling(c => c.DistributedCacheAction())
                 .ShouldReturn()
                 .Ok();
@@ -269,7 +264,7 @@ namespace MyTested.AspNetCore.Mvc.Test
 
             // second call should not have cache entries
             controller
-                .WithDistributedCache(cache => cache.WithEntry("test", new byte[] { 127, 127,127 }))
+                .WithDistributedCache(cache => cache.WithEntry("test", new byte[] { 127, 127, 127 }))
                 .Calling(c => c.DistributedCacheAction())
                 .ShouldReturn()
                 .Ok();

--- a/test/MyTested.AspNetCore.Mvc.Caching.Test/ServicesTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Caching.Test/ServicesTests.cs
@@ -6,7 +6,6 @@ namespace MyTested.AspNetCore.Mvc.Test
     using System.Threading.Tasks;
     using Internal;
     using Internal.Caching;
-    using Internal.Contracts;
     using Internal.Services;
     using Microsoft.Extensions.Caching.Distributed;
     using Microsoft.Extensions.Caching.Memory;

--- a/test/MyTested.AspNetCore.Mvc.Caching.Test/Setups/Controllers/DistributedCacheController.cs
+++ b/test/MyTested.AspNetCore.Mvc.Caching.Test/Setups/Controllers/DistributedCacheController.cs
@@ -1,6 +1,5 @@
 ﻿namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
 {
-    using System;
     using System.Collections.Generic;
     using Internal.Contracts;
     using Microsoft.AspNetCore.Mvc;

--- a/test/MyTested.AspNetCore.Mvc.Configuration.Test/MyTested.AspNetCore.Mvc.Configuration.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Configuration.Test/MyTested.AspNetCore.Mvc.Configuration.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Configuration.Test/MyTested.AspNetCore.Mvc.Configuration.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Configuration.Test/MyTested.AspNetCore.Mvc.Configuration.Test.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.ActionResults.Test.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test/MyTested.AspNetCore.Mvc.Controllers.Attributes.Test.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Test/MyTested.AspNetCore.Mvc.Controllers.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Test/MyTested.AspNetCore.Mvc.Controllers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Test/MyTested.AspNetCore.Mvc.Controllers.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Test/MyTested.AspNetCore.Mvc.Controllers.Test.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Test/ServicesTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Test/ServicesTests.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable xUnit1030
-#pragma warning disable xUnit1031
-namespace MyTested.AspNetCore.Mvc.Test
+﻿namespace MyTested.AspNetCore.Mvc.Test
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
@@ -140,7 +138,7 @@ namespace MyTested.AspNetCore.Mvc.Test
         }
 
         [Fact]
-        public void IActionContextAccessorShouldWorkCorrectlyAsynchronously()
+        public async Task IActionContextAccessorShouldWorkCorrectlyAsynchronously()
         {
             MyApplication
                 .StartsFrom<DefaultStartup>()
@@ -149,7 +147,7 @@ namespace MyTested.AspNetCore.Mvc.Test
                     services.AddActionContextAccessor();
                 });
 
-            Task
+            await Task
                 .Run(async () =>
                 {
                     ActionContext firstContextAsync = null;
@@ -225,10 +223,7 @@ namespace MyTested.AspNetCore.Mvc.Test
                     Assert.NotSame(thirdContextAsync, fourthContextAsync);
                     Assert.NotSame(fourthContextAsync, fifthContextAsync);
                     Assert.NotSame(thirdContextAsync, fifthContextAsync);
-                })
-                .ConfigureAwait(false)
-                .GetAwaiter()
-                .GetResult();
+                });
 
             MyApplication.StartsFrom<DefaultStartup>();
         }
@@ -312,7 +307,7 @@ namespace MyTested.AspNetCore.Mvc.Test
 
             MyApplication.StartsFrom<DefaultStartup>();
         }
-        
+
         [Fact]
         public void WithControllerContextFuncShouldSetItToAccessor()
         {
@@ -323,7 +318,7 @@ namespace MyTested.AspNetCore.Mvc.Test
                     services.AddActionContextAccessor();
                 });
 
-            var actionDescriptor = new ControllerActionDescriptor { DisplayName = "Test" };;
+            var actionDescriptor = new ControllerActionDescriptor { DisplayName = "Test" };
 
             MyController<ActionContextController>
                 .Instance()

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Test/ServicesTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Test/ServicesTests.cs
@@ -1,4 +1,6 @@
-﻿namespace MyTested.AspNetCore.Mvc.Test
+﻿#pragma warning disable xUnit1030
+#pragma warning disable xUnit1031
+namespace MyTested.AspNetCore.Mvc.Test
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test/MyTested.AspNetCore.Mvc.Controllers.Views.ActionResults.Test.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Views.Test/MyTested.AspNetCore.Mvc.Controllers.Views.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Views.Test/MyTested.AspNetCore.Mvc.Controllers.Views.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/MyTested.AspNetCore.Mvc.Controllers.Views.Test/MyTested.AspNetCore.Mvc.Controllers.Views.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Controllers.Views.Test/MyTested.AspNetCore.Mvc.Controllers.Views.Test.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.DataAnnotations.Test/MyTested.AspNetCore.Mvc.DataAnnotations.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.DataAnnotations.Test/MyTested.AspNetCore.Mvc.DataAnnotations.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.DataAnnotations.Test/MyTested.AspNetCore.Mvc.DataAnnotations.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.DataAnnotations.Test/MyTested.AspNetCore.Mvc.DataAnnotations.Test.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.DependencyInjection.Test/MyTested.AspNetCore.Mvc.DependencyInjection.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.DependencyInjection.Test/MyTested.AspNetCore.Mvc.DependencyInjection.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.DependencyInjection.Test/MyTested.AspNetCore.Mvc.DependencyInjection.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.DependencyInjection.Test/MyTested.AspNetCore.Mvc.DependencyInjection.Test.csproj
@@ -29,9 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test.csproj
@@ -29,10 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test/MyTested.AspNetCore.Mvc.EntityFrameworkCore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Helpers.Test/MyTested.AspNetCore.Mvc.Helpers.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Helpers.Test/MyTested.AspNetCore.Mvc.Helpers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Helpers.Test/MyTested.AspNetCore.Mvc.Helpers.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Helpers.Test/MyTested.AspNetCore.Mvc.Helpers.Test.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Http.Test/BuildersTests/HttpTests/HttpResponseTestBuilderTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Http.Test/BuildersTests/HttpTests/HttpResponseTestBuilderTests.cs
@@ -287,7 +287,7 @@
                         .ShouldHave()
                         .HttpResponse(response => response.ContainingCookie("Test"));
                 },
-                "When calling CustomCookieHeadersAction action in MvcController expected HTTP response to have set cookies, but none were found.");
+                "When calling CustomCookieHeadersAction action in MvcController expected HTTP response headers to contain header with 'Set-Cookie' name, but such was not found.");
         }
 
         [Fact]
@@ -302,7 +302,7 @@
                         .ShouldHave()
                         .HttpResponse(response => response.ContainingCookie("Test"));
                 },
-                "When calling CustomCookieHeadersAction action in MvcController expected HTTP response to have valid cookie values, but some of them were invalid.");
+                "When calling CustomCookieHeadersAction action in MvcController expected HTTP response headers to contain header with 'Set-Cookie' name, but such was not found.");
         }
 
         [Fact]

--- a/test/MyTested.AspNetCore.Mvc.Http.Test/MyTested.AspNetCore.Mvc.Http.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Http.Test/MyTested.AspNetCore.Mvc.Http.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Http.Test/MyTested.AspNetCore.Mvc.Http.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Http.Test/MyTested.AspNetCore.Mvc.Http.Test.csproj
@@ -28,9 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Http.Test/ServicesTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Http.Test/ServicesTests.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable xUnit1030
-#pragma warning disable xUnit1031
-namespace MyTested.AspNetCore.Mvc.Test
+﻿namespace MyTested.AspNetCore.Mvc.Test
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -82,7 +80,7 @@ namespace MyTested.AspNetCore.Mvc.Test
         }
 
         [Fact]
-        public void HttpContextAccessorShouldWorkCorrectlyAsynchronously()
+        public async Task HttpContextAccessorShouldWorkCorrectlyAsynchronously()
         {
             MyApplication
                 .StartsFrom<DefaultStartup>()
@@ -91,7 +89,7 @@ namespace MyTested.AspNetCore.Mvc.Test
                     services.AddHttpContextAccessor();
                 });
 
-            Task
+            await Task
                 .Run(async () =>
                 {
                     HttpContext firstContextAsync = null;
@@ -167,10 +165,7 @@ namespace MyTested.AspNetCore.Mvc.Test
                     Assert.NotSame(thirdContextAsync, fourthContextAsync);
                     Assert.NotSame(fourthContextAsync, fifthContextAsync);
                     Assert.NotSame(thirdContextAsync, fifthContextAsync);
-                })
-                .ConfigureAwait(false)
-                .GetAwaiter()
-                .GetResult();
+                });
 
             MyApplication.StartsFrom<DefaultStartup>();
         }

--- a/test/MyTested.AspNetCore.Mvc.Http.Test/ServicesTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Http.Test/ServicesTests.cs
@@ -1,4 +1,6 @@
-﻿namespace MyTested.AspNetCore.Mvc.Test
+﻿#pragma warning disable xUnit1030
+#pragma warning disable xUnit1031
+namespace MyTested.AspNetCore.Mvc.Test
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -34,7 +36,7 @@
 
             Assert.Equal(120, builtOptions.Value.MaxModelValidationErrors);
             Assert.Contains(typeof(StringInputFormatter), builtOptions.Value.InputFormatters.Select(f => f.GetType()));
-            Assert.Equal(1, builtOptions.Value.Conventions.Count);
+            Assert.Single(builtOptions.Value.Conventions);
 
             MyApplication.StartsFrom<DefaultStartup>();
         }

--- a/test/MyTested.AspNetCore.Mvc.ModelState.Test/BuildersTests/ActionsTests/ShouldHaveTests/ShouldHaveModelStateTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.ModelState.Test/BuildersTests/ActionsTests/ShouldHaveTests/ShouldHaveModelStateTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.ActionsTests.ShouldHaveTests
 {
     using Exceptions;
-    using Microsoft.Extensions.DependencyInjection;
-    using Plugins;
     using Setups;
     using Setups.Controllers;
     using Setups.ViewComponents;

--- a/test/MyTested.AspNetCore.Mvc.ModelState.Test/MyTested.AspNetCore.Mvc.ModelState.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ModelState.Test/MyTested.AspNetCore.Mvc.ModelState.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ModelState.Test/MyTested.AspNetCore.Mvc.ModelState.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ModelState.Test/MyTested.AspNetCore.Mvc.ModelState.Test.csproj
@@ -29,9 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Models.Test/MyTested.AspNetCore.Mvc.Models.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Models.Test/MyTested.AspNetCore.Mvc.Models.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Models.Test/MyTested.AspNetCore.Mvc.Models.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Models.Test/MyTested.AspNetCore.Mvc.Models.Test.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test/MyTested.AspNetCore.Mvc.NewtonsoftJson.Test.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Options.Test/MyTested.AspNetCore.Mvc.Options.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Options.Test/MyTested.AspNetCore.Mvc.Options.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Options.Test/MyTested.AspNetCore.Mvc.Options.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Options.Test/MyTested.AspNetCore.Mvc.Options.Test.csproj
@@ -28,10 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Pipeline.Test/MyTested.AspNetCore.Mvc.Pipeline.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Pipeline.Test/MyTested.AspNetCore.Mvc.Pipeline.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Pipeline.Test/MyTested.AspNetCore.Mvc.Pipeline.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Pipeline.Test/MyTested.AspNetCore.Mvc.Pipeline.Test.csproj
@@ -29,9 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test/MyTested.AspNetCore.Mvc.Razor.RuntimeCompilation.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Routing.Test/InternalTests/RoutingTests/MvcRouteResolverTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Routing.Test/InternalTests/RoutingTests/MvcRouteResolverTests.cs
@@ -29,7 +29,7 @@
             Assert.Equal(typeof(HomeController).GetTypeInfo(), routeInfo.ControllerType);
             Assert.Equal("Home", routeInfo.ControllerName);
             Assert.Equal("Index", routeInfo.Action);
-            Assert.Equal(0, routeInfo.ActionArguments.Count);
+            Assert.Empty(routeInfo.ActionArguments);
             Assert.True(routeInfo.ModelState.IsValid);
         }
 
@@ -46,7 +46,7 @@
             Assert.Equal(typeof(NormalController).GetTypeInfo(), routeInfo.ControllerType);
             Assert.Equal("Normal", routeInfo.ControllerName);
             Assert.Equal("AnotherName", routeInfo.Action);
-            Assert.Equal(0, routeInfo.ActionArguments.Count);
+            Assert.Empty(routeInfo.ActionArguments);
             Assert.True(routeInfo.ModelState.IsValid);
         }
 
@@ -63,7 +63,7 @@
             Assert.Equal(typeof(RouteController).GetTypeInfo(), routeInfo.ControllerType);
             Assert.Equal("Route", routeInfo.ControllerName);
             Assert.Equal("Index", routeInfo.Action);
-            Assert.Equal(0, routeInfo.ActionArguments.Count);
+            Assert.Empty(routeInfo.ActionArguments);
             Assert.True(routeInfo.ModelState.IsValid);
         }
 
@@ -80,7 +80,7 @@
             Assert.Equal(typeof(NormalController).GetTypeInfo(), routeInfo.ControllerType);
             Assert.Equal("Normal", routeInfo.ControllerName);
             Assert.Equal("ActionWithParameters", routeInfo.Action);
-            Assert.Equal(1, routeInfo.ActionArguments.Count);
+            Assert.Single(routeInfo.ActionArguments);
             Assert.Equal(5, routeInfo.ActionArguments["id"].Value);
             Assert.True(routeInfo.ModelState.IsValid);
         }
@@ -98,7 +98,7 @@
             Assert.Equal(typeof(NormalController).GetTypeInfo(), routeInfo.ControllerType);
             Assert.Equal("Normal", routeInfo.ControllerName);
             Assert.Equal("ActionWithStringParameters", routeInfo.Action);
-            Assert.Equal(1, routeInfo.ActionArguments.Count);
+            Assert.Single(routeInfo.ActionArguments);
             Assert.Equal("Test", routeInfo.ActionArguments["id"].Value);
             Assert.True(routeInfo.ModelState.IsValid);
         }
@@ -116,7 +116,7 @@
             Assert.Equal(typeof(NormalController).GetTypeInfo(), routeInfo.ControllerType);
             Assert.Equal("Normal", routeInfo.ControllerName);
             Assert.Equal("ActionWithParameters", routeInfo.Action);
-            Assert.Equal(0, routeInfo.ActionArguments.Count);
+            Assert.Empty(routeInfo.ActionArguments);
             Assert.False(routeInfo.ModelState.IsValid);
         }
 
@@ -153,7 +153,7 @@
             Assert.Equal(typeof(NormalController).GetTypeInfo(), routeInfo.ControllerType);
             Assert.Equal("Normal", routeInfo.ControllerName);
             Assert.Equal("GetMethod", routeInfo.Action);
-            Assert.Equal(0, routeInfo.ActionArguments.Count);
+            Assert.Empty(routeInfo.ActionArguments);
             Assert.True(routeInfo.ModelState.IsValid);
         }
 
@@ -206,7 +206,7 @@
             Assert.Equal(typeof(NormalController).GetTypeInfo(), routeInfo.ControllerType);
             Assert.Equal("Normal", routeInfo.ControllerName);
             Assert.Equal("QueryString", routeInfo.Action);
-            Assert.Equal(1, routeInfo.ActionArguments.Count);
+            Assert.Single(routeInfo.ActionArguments);
             Assert.Equal("test", routeInfo.ActionArguments["first"].Value);
             Assert.True(routeInfo.ModelState.IsValid);
         }
@@ -224,7 +224,7 @@
             Assert.Equal(typeof(NormalController).GetTypeInfo(), routeInfo.ControllerType);
             Assert.Equal("Normal", routeInfo.ControllerName);
             Assert.Equal("QueryString", routeInfo.Action);
-            Assert.Equal(0, routeInfo.ActionArguments.Count);
+            Assert.Empty(routeInfo.ActionArguments);
             Assert.True(routeInfo.ModelState.IsValid);
         }
 
@@ -267,7 +267,7 @@
             Assert.Equal(typeof(NormalController).GetTypeInfo(), routeInfo.ControllerType);
             Assert.Equal("Normal", routeInfo.ControllerName);
             Assert.Equal("ActionWithModel", routeInfo.Action);
-            Assert.Equal(1, routeInfo.ActionArguments.Count);
+            Assert.Single(routeInfo.ActionArguments);
             Assert.Equal(5, routeInfo.ActionArguments["id"].Value);
             Assert.False(routeInfo.ActionArguments.ContainsKey("model"));
             Assert.False(routeInfo.ModelState.IsValid);
@@ -344,7 +344,7 @@
             Assert.Equal(typeof(NormalController).GetTypeInfo(), routeInfo.ControllerType);
             Assert.Equal("Normal", routeInfo.ControllerName);
             Assert.Equal("FiltersAction", routeInfo.Action);
-            Assert.Equal(0, routeInfo.ActionArguments.Count);
+            Assert.Empty(routeInfo.ActionArguments);
             Assert.True(routeInfo.ModelState.IsValid);
         }
 

--- a/test/MyTested.AspNetCore.Mvc.Routing.Test/InternalTests/RoutingTests/RouteExpressionParserTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Routing.Test/InternalTests/RoutingTests/RouteExpressionParserTests.cs
@@ -24,7 +24,7 @@
 
             Assert.Equal(controllerName, result.ControllerName);
             Assert.Equal(actionName, result.Action);
-            Assert.Equal(0, result.ActionArguments.Count);
+            Assert.Empty(result.ActionArguments);
         }
 
         [Theory]
@@ -53,7 +53,7 @@
 
             Assert.Equal("Route", result.ControllerName);
             Assert.Equal("Index", result.Action);
-            Assert.Equal(0, result.ActionArguments.Count);
+            Assert.Empty(result.ActionArguments);
         }
 
         [Fact]
@@ -82,7 +82,7 @@
 
             Assert.Equal("Poco", result.ControllerName);
             Assert.Equal("Action", result.Action);
-            Assert.Equal(1, result.ActionArguments.Count);
+            Assert.Single(result.ActionArguments);
             Assert.True(result.ActionArguments.ContainsKey("id"));
             Assert.Equal(1, result.ActionArguments["id"].Value);
         }
@@ -101,7 +101,7 @@
             Assert.True(result.ActionArguments.ContainsKey("area"));
             Assert.Equal("MyArea", result.ActionArguments["area"].Value);
         }
-        
+
         [Fact]
         public void ParseCustomConventionsCustomConventionsAreParsed()
         {
@@ -110,7 +110,7 @@
 
             Assert.Equal("ChangedController", result.ControllerName);
             Assert.Equal("ChangedAction", result.Action);
-            Assert.Equal(1, result.ActionArguments.Count);
+            Assert.Single(result.ActionArguments);
             Assert.True(result.ActionArguments.ContainsKey("ChangedParameter"));
             Assert.Equal(1, result.ActionArguments["ChangedParameter"].Value);
         }
@@ -123,7 +123,7 @@
 
             Assert.Equal("ChangedController", result.ControllerName);
             Assert.Equal("ChangedAction", result.Action);
-            Assert.Equal(1, result.ActionArguments.Count);
+            Assert.Single(result.ActionArguments);
             Assert.True(result.ActionArguments.ContainsKey("id"));
             Assert.Equal(1, result.ActionArguments["id"].Value);
         }
@@ -197,13 +197,13 @@
                     controllerName,
                     actionName,
                     new Dictionary<string, object> { ["id"] = 1 });
-                
+
                 data.Add(
                     c => c.ActionWithOverloads(With.No<int?>()),
                     controllerName,
                     actionName,
                     new Dictionary<string, object>());
-                
+
                 data.Add(
                     c => c.ActionWithOverloads(With.No<int>()),
                     controllerName,

--- a/test/MyTested.AspNetCore.Mvc.Routing.Test/MyTested.AspNetCore.Mvc.Routing.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Routing.Test/MyTested.AspNetCore.Mvc.Routing.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Routing.Test/MyTested.AspNetCore.Mvc.Routing.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Routing.Test/MyTested.AspNetCore.Mvc.Routing.Test.csproj
@@ -29,9 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Session.Test/MyTested.AspNetCore.Mvc.Session.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Session.Test/MyTested.AspNetCore.Mvc.Session.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Session.Test/MyTested.AspNetCore.Mvc.Session.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Session.Test/MyTested.AspNetCore.Mvc.Session.Test.csproj
@@ -29,9 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.TempData.Test/BuildersTests/ControllersTests/ControllerBuilderTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.TempData.Test/BuildersTests/ControllersTests/ControllerBuilderTests.cs
@@ -41,7 +41,7 @@
                     .WithEntry("key", "value"))
                 .ShouldPassForThe<MvcController>(controller =>
                 {
-                    Assert.Equal(1, controller.TempData.Count);
+                    Assert.Single(controller.TempData);
                 });
         }
 

--- a/test/MyTested.AspNetCore.Mvc.TempData.Test/BuildersTests/ViewComponentsTests/ViewComponentBuilderTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.TempData.Test/BuildersTests/ViewComponentsTests/ViewComponentBuilderTests.cs
@@ -41,7 +41,7 @@
                     .WithEntry("key", "value"))
                 .ShouldPassForThe<TempDataComponent>(viewComponent =>
                 {
-                    Assert.Equal(1, viewComponent.ViewContext.TempData.Count);
+                    Assert.Single(viewComponent.ViewContext.TempData);
                 });
         }
 
@@ -62,7 +62,7 @@
                 .Result("POCO")
                 .ShouldPassForThe<PocoViewComponent>(viewComponent =>
                 {
-                    Assert.Equal(1, viewComponent.Context.ViewContext.TempData.Count);
+                    Assert.Single(viewComponent.Context.ViewContext.TempData);
                 });
 
             MyApplication.StartsFrom<DefaultStartup>();

--- a/test/MyTested.AspNetCore.Mvc.TempData.Test/MyTested.AspNetCore.Mvc.TempData.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.TempData.Test/MyTested.AspNetCore.Mvc.TempData.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.TempData.Test/MyTested.AspNetCore.Mvc.TempData.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.TempData.Test/MyTested.AspNetCore.Mvc.TempData.Test.csproj
@@ -29,9 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Test.Setups/Controllers/InheritControllerAttributes.cs
+++ b/test/MyTested.AspNetCore.Mvc.Test.Setups/Controllers/InheritControllerAttributes.cs
@@ -1,6 +1,5 @@
 ﻿namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
 {
-    using System;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 

--- a/test/MyTested.AspNetCore.Mvc.Test.Setups/Controllers/MvcController.cs
+++ b/test/MyTested.AspNetCore.Mvc.Test.Setups/Controllers/MvcController.cs
@@ -225,7 +225,7 @@
 
         public void CustomCookieHeadersAction(string cookie)
         {
-            this.Response.Headers.Add("Set-Cookie", cookie);
+            this.Response.Headers.Append("Set-Cookie", cookie);
         }
 
         public IActionResult CustomResponseAction()

--- a/test/MyTested.AspNetCore.Mvc.Test.Setups/MyTested.AspNetCore.Mvc.Test.Setups.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Test.Setups/MyTested.AspNetCore.Mvc.Test.Setups.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test.Setups</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Test.Setups/MyTested.AspNetCore.Mvc.Test.Setups.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Test.Setups/MyTested.AspNetCore.Mvc.Test.Setups.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Test.Setups/TestObjectFactory.cs
+++ b/test/MyTested.AspNetCore.Mvc.Test.Setups/TestObjectFactory.cs
@@ -76,9 +76,9 @@
 
             response.ContentType = ContentType.ApplicationJson;
             response.StatusCode = 500;
-            response.Headers.Add("TestHeader", "TestHeaderValue");
-            response.Headers.Add("AnotherTestHeader", "AnotherTestHeaderValue");
-            response.Headers.Add("MultipleTestHeader", new[] { "FirstMultipleTestHeaderValue", "AnotherMultipleTestHeaderValue" });
+            response.Headers.Append("TestHeader", "TestHeaderValue");
+            response.Headers.Append("AnotherTestHeader", "AnotherTestHeaderValue");
+            response.Headers.Append("MultipleTestHeader", new[] { "FirstMultipleTestHeaderValue", "AnotherMultipleTestHeaderValue" });
             response.Cookies.Append(
                 "TestCookie",
                 "TestCookieValue",

--- a/test/MyTested.AspNetCore.Mvc.Test/MyTested.AspNetCore.Mvc.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Test/MyTested.AspNetCore.Mvc.Test.csproj
@@ -25,9 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
   
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Test/MyTested.AspNetCore.Mvc.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Test/MyTested.AspNetCore.Mvc.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Universe.Test/MyTested.AspNetCore.Mvc.Universe.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Universe.Test/MyTested.AspNetCore.Mvc.Universe.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Universe.Test/MyTested.AspNetCore.Mvc.Universe.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Universe.Test/MyTested.AspNetCore.Mvc.Universe.Test.csproj
@@ -26,10 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/MyTested.AspNetCore.Mvc.Versioning.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/MyTested.AspNetCore.Mvc.Versioning.Test.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/MyTested.AspNetCore.Mvc.Versioning.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/MyTested.AspNetCore.Mvc.Versioning.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/QueryVersioningController.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/QueryVersioningController.cs
@@ -5,7 +5,7 @@
     [ApiController]
     [ApiVersion("2.0")]
     [Route("api/versioning")]
-    public class QueryVersioningController : Controller
+    public class QueryVersioningController : ControllerBase
     {
         [HttpGet]
         public IActionResult Index() => this.Ok();

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/VersioningController.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/VersioningController.cs
@@ -4,8 +4,9 @@
 
     [ApiController]
     [ApiVersion("2.0")]
+    [ApiVersion("3.0")]
     [Route("api/v{version:apiVersion}/[controller]")]
-    public class VersioningController : Controller
+    public class VersioningController : ControllerBase
     {
         [HttpGet]
         public IActionResult Index() => this.Ok();

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test/MyTested.AspNetCore.Mvc.ViewComponents.Attributes.Test.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test/MyTested.AspNetCore.Mvc.ViewComponents.Results.Test.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/MyTested.AspNetCore.Mvc.ViewComponents.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/MyTested.AspNetCore.Mvc.ViewComponents.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/MyTested.AspNetCore.Mvc.ViewComponents.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/MyTested.AspNetCore.Mvc.ViewComponents.Test.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/ServicesTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/ServicesTests.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable xUnit1030
-#pragma warning disable xUnit1031
-namespace MyTested.AspNetCore.Mvc.Test
+﻿namespace MyTested.AspNetCore.Mvc.Test
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
@@ -155,7 +153,7 @@ namespace MyTested.AspNetCore.Mvc.Test
         }
 
         [Fact]
-        public void IActionContextAccessorShouldWorkCorrectlyAsynchronously()
+        public async Task IActionContextAccessorShouldWorkCorrectlyAsynchronously()
         {
             MyApplication
                 .StartsFrom<DefaultStartup>()
@@ -164,7 +162,7 @@ namespace MyTested.AspNetCore.Mvc.Test
                     services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
                 });
 
-            Task
+            await Task
                 .Run(async () =>
                 {
                     ActionContext firstContextAsync = null;
@@ -240,10 +238,7 @@ namespace MyTested.AspNetCore.Mvc.Test
                     Assert.NotSame(thirdContextAsync, fourthContextAsync);
                     Assert.NotSame(fourthContextAsync, fifthContextAsync);
                     Assert.NotSame(thirdContextAsync, fifthContextAsync);
-                })
-                .ConfigureAwait(false)
-                .GetAwaiter()
-                .GetResult();
+                });
 
             MyApplication.StartsFrom<DefaultStartup>();
         }

--- a/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/ServicesTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.ViewComponents.Test/ServicesTests.cs
@@ -1,4 +1,6 @@
-﻿namespace MyTested.AspNetCore.Mvc.Test
+﻿#pragma warning disable xUnit1030
+#pragma warning disable xUnit1031
+namespace MyTested.AspNetCore.Mvc.Test
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
@@ -115,7 +117,7 @@
                 },
                 "ServicesComponent could not be instantiated because it contains no constructor taking no parameters.");
         }
-        
+
         [Fact]
         public void IActionContextAccessorShouldWorkCorrectlySynchronously()
         {
@@ -415,7 +417,7 @@
                 });
 
             var actionDescriptor = new ActionDescriptor { DisplayName = "Test" };
-            
+
             MyViewComponent<AccessorComponent>
                 .Instance()
                 .WithViewComponentContext(context =>
@@ -431,7 +433,7 @@
 
             MyApplication.StartsFrom<DefaultStartup>();
         }
-        
+
         [Fact]
         public void WithCustomViewContextShouldSetItToAccessor()
         {

--- a/test/MyTested.AspNetCore.Mvc.ViewData.Test/MyTested.AspNetCore.Mvc.ViewData.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewData.Test/MyTested.AspNetCore.Mvc.ViewData.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ViewData.Test/MyTested.AspNetCore.Mvc.ViewData.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewData.Test/MyTested.AspNetCore.Mvc.ViewData.Test.csproj
@@ -28,9 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>

--- a/test/MyTested.AspNetCore.Mvc.ViewData.Test/PluginsTests/ViewDataTestPluginTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.ViewData.Test/PluginsTests/ViewDataTestPluginTests.cs
@@ -33,7 +33,7 @@
 
             testPlugin.DefaultServiceRegistrationDelegate(serviceCollection);
 
-            Assert.True(serviceCollection.Count == 166);
+            Assert.True(serviceCollection.Count == 191);
         }
     }
 }

--- a/test/MyTested.AspNetCore.Mvc.ViewFeatures.Test/MyTested.AspNetCore.Mvc.ViewFeatures.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewFeatures.Test/MyTested.AspNetCore.Mvc.ViewFeatures.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MyTested.AspNetCore.Mvc.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>

--- a/test/MyTested.AspNetCore.Mvc.ViewFeatures.Test/MyTested.AspNetCore.Mvc.ViewFeatures.Test.csproj
+++ b/test/MyTested.AspNetCore.Mvc.ViewFeatures.Test/MyTested.AspNetCore.Mvc.ViewFeatures.Test.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.6.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Prerequisites:

- Visual Studio 2022 with the ASP.NET and web development workload
- .NET 8.0 SDK or later

Full list: https://learn.microsoft.com/en-us/aspnet/core/migration/70-80?view=aspnetcore-8.0&tabs=visual-studio

- Upgrade TargetFramework to net8.0 and VersionPrefix to 8.0.0
- Updated all packages to their latest stable version
- Improved ApplicationBuilderMock class
- Fixed xUnit warnings
- Added new tests in .appyeveyor.yml