### PR TITLE
Add Versioning Support via Asp.Versioning

### DIFF
--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionActionConstraint.cs
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionActionConstraint.cs
@@ -5,6 +5,8 @@ namespace MyTested.AspNetCore.Mvc.Internal
     using Microsoft.AspNetCore.Mvc.Abstractions;
     using Microsoft.AspNetCore.Mvc.ActionConstraints;
     using Microsoft.AspNetCore.Routing;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Options;
 
     internal class ApiVersionActionConstraint : IActionConstraint
     {
@@ -67,16 +69,20 @@ namespace MyTested.AspNetCore.Mvc.Internal
                 return parsedVersion;
             }
 
-            var queryVersion = context.HttpContext.Request.Query["api-version"].FirstOrDefault();
-            if (queryVersion != null && parser.TryParse(queryVersion, out var parsedQueryVersion))
-            {
-                return parsedQueryVersion;
-            }
+            var reader = context.HttpContext.RequestServices
+                ?.GetService<IOptions<ApiVersioningOptions>>()
+                ?.Value
+                ?.ApiVersionReader;
 
-            var headerVersion = context.HttpContext.Request.Headers["x-api-version"].FirstOrDefault();
-            if (headerVersion != null && parser.TryParse(headerVersion, out var parsedHeaderVersion))
+            if (reader != null)
             {
-                return parsedHeaderVersion;
+                var rawVersions = reader.Read(context.HttpContext.Request);
+
+                if (rawVersions.Count > 0
+                    && parser.TryParse(rawVersions[0], out var parsedReaderVersion))
+                {
+                    return parsedReaderVersion;
+                }
             }
 
             return null;

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionActionConstraint.cs
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionActionConstraint.cs
@@ -1,0 +1,79 @@
+namespace MyTested.AspNetCore.Mvc.Internal
+{
+    using System.Linq;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc.Abstractions;
+    using Microsoft.AspNetCore.Mvc.ActionConstraints;
+    using Microsoft.AspNetCore.Routing;
+
+    internal class ApiVersionActionConstraint : IActionConstraint
+    {
+        public int Order => 0;
+
+        public bool Accept(ActionConstraintContext context)
+        {
+            var requestedVersion = GetRequestedApiVersion(context.RouteContext);
+
+            if (requestedVersion == null)
+            {
+                return true;
+            }
+
+            var metadata = context.CurrentCandidate.Action.GetApiVersionMetadata();
+
+            if (metadata == ApiVersionMetadata.Empty || metadata.IsApiVersionNeutral)
+            {
+                return true;
+            }
+
+            if (!metadata.IsMappedTo(requestedVersion))
+            {
+                return false;
+            }
+
+            if (context.Candidates.Count <= 1)
+            {
+                return true;
+            }
+
+            var mapping = metadata.MappingTo(requestedVersion);
+            if (mapping == ApiVersionMapping.Explicit)
+            {
+                return true;
+            }
+
+            var hasExplicitCandidate = context.Candidates.Any(c =>
+            {
+                if (c.Action == context.CurrentCandidate.Action)
+                {
+                    return false;
+                }
+
+                var otherMetadata = c.Action.GetApiVersionMetadata();
+                return otherMetadata.MappingTo(requestedVersion) == ApiVersionMapping.Explicit;
+            });
+
+            return !hasExplicitCandidate;
+        }
+
+        private static ApiVersion GetRequestedApiVersion(RouteContext context)
+        {
+            var parser = ApiVersionParser.Default;
+
+            if (context.RouteData.Values.TryGetValue("version", out var routeVersion)
+                && routeVersion is string versionString
+                && parser.TryParse(versionString, out var parsedVersion))
+            {
+                return parsedVersion;
+            }
+
+            var queryVersion = context.HttpContext.Request.Query["api-version"].FirstOrDefault();
+            if (queryVersion != null && parser.TryParse(queryVersion, out var parsedQueryVersion))
+            {
+                return parsedQueryVersion;
+            }
+
+            return null;
+        }
+    }
+}

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionActionConstraint.cs
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionActionConstraint.cs
@@ -73,6 +73,12 @@ namespace MyTested.AspNetCore.Mvc.Internal
                 return parsedQueryVersion;
             }
 
+            var headerVersion = context.HttpContext.Request.Headers["x-api-version"].FirstOrDefault();
+            if (headerVersion != null && parser.TryParse(headerVersion, out var parsedHeaderVersion))
+            {
+                return parsedHeaderVersion;
+            }
+
             return null;
         }
     }

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionActionConstraintProvider.cs
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionActionConstraintProvider.cs
@@ -1,0 +1,31 @@
+namespace MyTested.AspNetCore.Mvc.Internal
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc.Abstractions;
+    using Microsoft.AspNetCore.Mvc.ActionConstraints;
+
+    internal class ApiVersionActionConstraintProvider : IActionConstraintProvider
+    {
+        private static readonly ApiVersionActionConstraint SharedConstraint = new();
+
+        public int Order => -1000;
+
+        public void OnProvidersExecuting(ActionConstraintProviderContext context)
+        {
+            var metadata = context.Action.GetApiVersionMetadata();
+
+            if (metadata != ApiVersionMetadata.Empty && !metadata.IsApiVersionNeutral)
+            {
+                context.Results.Add(new ActionConstraintItem(SharedConstraint)
+                {
+                    Constraint = SharedConstraint,
+                    IsReusable = true
+                });
+            }
+        }
+
+        public void OnProvidersExecuted(ActionConstraintProviderContext context)
+        {
+        }
+    }
+}

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionAwareActionSelector.cs
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionAwareActionSelector.cs
@@ -1,0 +1,87 @@
+namespace MyTested.AspNetCore.Mvc.Internal
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc.Abstractions;
+    using Microsoft.AspNetCore.Mvc.Infrastructure;
+    using Microsoft.AspNetCore.Routing;
+
+    internal class ApiVersionAwareActionSelector : IActionSelector
+    {
+        private readonly IActionSelector inner;
+
+        public ApiVersionAwareActionSelector(IActionSelector inner)
+        {
+            this.inner = inner;
+        }
+
+        public IReadOnlyList<ActionDescriptor> SelectCandidates(RouteContext context)
+            => this.inner.SelectCandidates(context);
+
+        public ActionDescriptor SelectBestCandidate(
+            RouteContext context,
+            IReadOnlyList<ActionDescriptor> candidates)
+        {
+            var requestedVersion = GetRequestedApiVersion(context);
+
+            if (requestedVersion == null)
+            {
+                return this.inner.SelectBestCandidate(context, candidates);
+            }
+
+            var versionedCandidates = new List<ActionDescriptor>();
+
+            foreach (var candidate in candidates)
+            {
+                var metadata = candidate.GetApiVersionMetadata();
+
+                if (metadata == ApiVersionMetadata.Empty
+                    || metadata.IsApiVersionNeutral
+                    || metadata.IsMappedTo(requestedVersion))
+                {
+                    versionedCandidates.Add(candidate);
+                }
+            }
+
+            if (versionedCandidates.Count == 0)
+            {
+                return null;
+            }
+
+            if (versionedCandidates.Count > 1)
+            {
+                var explicitlyMapped = versionedCandidates
+                    .Where(c => c.GetApiVersionMetadata().MappingTo(requestedVersion) == ApiVersionMapping.Explicit)
+                    .ToList();
+
+                if (explicitlyMapped.Count > 0)
+                {
+                    versionedCandidates = explicitlyMapped;
+                }
+            }
+
+            return this.inner.SelectBestCandidate(context, versionedCandidates);
+        }
+
+        private static ApiVersion GetRequestedApiVersion(RouteContext context)
+        {
+            var parser = ApiVersionParser.Default;
+
+            if (context.RouteData.Values.TryGetValue("version", out var routeVersion)
+                && routeVersion is string versionString
+                && parser.TryParse(versionString, out var parsedVersion))
+            {
+                return parsedVersion;
+            }
+
+            var queryVersion = context.HttpContext.Request.Query["api-version"].FirstOrDefault();
+            if (queryVersion != null && parser.TryParse(queryVersion, out var parsedQueryVersion))
+            {
+                return parsedQueryVersion;
+            }
+
+            return null;
+        }
+    }
+}

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionAwareActionSelector.cs
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionAwareActionSelector.cs
@@ -81,6 +81,12 @@ namespace MyTested.AspNetCore.Mvc.Internal
                 return parsedQueryVersion;
             }
 
+            var headerVersion = context.HttpContext.Request.Headers["x-api-version"].FirstOrDefault();
+            if (headerVersion != null && parser.TryParse(headerVersion, out var parsedHeaderVersion))
+            {
+                return parsedHeaderVersion;
+            }
+
             return null;
         }
     }

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionAwareActionSelector.cs
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/Internal/ApiVersionAwareActionSelector.cs
@@ -6,6 +6,8 @@ namespace MyTested.AspNetCore.Mvc.Internal
     using Microsoft.AspNetCore.Mvc.Abstractions;
     using Microsoft.AspNetCore.Mvc.Infrastructure;
     using Microsoft.AspNetCore.Routing;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Options;
 
     internal class ApiVersionAwareActionSelector : IActionSelector
     {
@@ -75,16 +77,20 @@ namespace MyTested.AspNetCore.Mvc.Internal
                 return parsedVersion;
             }
 
-            var queryVersion = context.HttpContext.Request.Query["api-version"].FirstOrDefault();
-            if (queryVersion != null && parser.TryParse(queryVersion, out var parsedQueryVersion))
-            {
-                return parsedQueryVersion;
-            }
+            var reader = context.HttpContext.RequestServices
+                ?.GetService<IOptions<ApiVersioningOptions>>()
+                ?.Value
+                ?.ApiVersionReader;
 
-            var headerVersion = context.HttpContext.Request.Headers["x-api-version"].FirstOrDefault();
-            if (headerVersion != null && parser.TryParse(headerVersion, out var parsedHeaderVersion))
+            if (reader != null)
             {
-                return parsedHeaderVersion;
+                var rawVersions = reader.Read(context.HttpContext.Request);
+
+                if (rawVersions.Count > 0
+                    && parser.TryParse(rawVersions[0], out var parsedReaderVersion))
+                {
+                    return parsedReaderVersion;
+                }
             }
 
             return null;

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/MyTested.AspNetCore.Mvc.Versioning.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/MyTested.AspNetCore.Mvc.Versioning.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
     
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />
   </ItemGroup>
     

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/MyTested.AspNetCore.Mvc.Versioning.csproj
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/MyTested.AspNetCore.Mvc.Versioning.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />
   </ItemGroup>
     
   <ItemGroup>

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/Plugins/VersioningTestPlugin.cs
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/Plugins/VersioningTestPlugin.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc.Versioning;
+    using Asp.Versioning;
 
     public class VersioningTestPlugin : IHttpFeatureRegistrationPlugin
     {

--- a/plugins/MyTested.AspNetCore.Mvc.Versioning/Plugins/VersioningTestPlugin.cs
+++ b/plugins/MyTested.AspNetCore.Mvc.Versioning/Plugins/VersioningTestPlugin.cs
@@ -1,14 +1,49 @@
-﻿namespace MyTested.AspNetCore.Mvc.Plugins
+namespace MyTested.AspNetCore.Mvc.Plugins
 {
     using System;
-    using Microsoft.AspNetCore.Http;
+    using System.Linq;
     using Asp.Versioning;
+    using Internal;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc.ActionConstraints;
+    using Microsoft.AspNetCore.Mvc.Infrastructure;
+    using Microsoft.Extensions.DependencyInjection;
 
-    public class VersioningTestPlugin : IHttpFeatureRegistrationPlugin
+    public class VersioningTestPlugin
+        : IHttpFeatureRegistrationPlugin,
+          IServiceRegistrationPlugin,
+          IRoutingServiceRegistrationPlugin
     {
         public Action<HttpContext> HttpFeatureRegistrationDelegate
             => httpContext => httpContext
                 .Features
                 .Set<IApiVersioningFeature>(new ApiVersioningFeature(httpContext));
+
+        public Func<ServiceDescriptor, bool> ServiceSelectorPredicate
+            => serviceDescriptor
+                => serviceDescriptor.ServiceType == typeof(IActionConstraintProvider);
+
+        public Action<IServiceCollection> ServiceRegistrationDelegate
+            => serviceCollection
+                => serviceCollection.AddSingleton<IActionConstraintProvider, ApiVersionActionConstraintProvider>();
+
+        public Action<IServiceCollection> RoutingServiceRegistrationDelegate
+            => serviceCollection =>
+            {
+                var selectorDescriptor = serviceCollection
+                    .FirstOrDefault(d => d.ServiceType == typeof(IActionSelector));
+
+                if (selectorDescriptor != null)
+                {
+                    serviceCollection.Remove(selectorDescriptor);
+                    serviceCollection.AddSingleton<IActionSelector>(sp =>
+                    {
+                        var innerSelector = (IActionSelector)ActivatorUtilities
+                            .CreateInstance(sp, selectorDescriptor.ImplementationType);
+
+                        return new ApiVersionAwareActionSelector(innerSelector);
+                    });
+                }
+            };
     }
 }

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/BuildersTests/PipelineTests/WhichControllerInstanceBuilderTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/BuildersTests/PipelineTests/WhichControllerInstanceBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.PipelineTests
+namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.PipelineTests
 {
     using Setups.Controllers;
     using Xunit;
@@ -30,12 +30,128 @@
         }
 
         [Fact]
-        public void RouteAssertionShouldWorkCorrectlyWithActionVersioningWhichDoesNotExist()
+        public void PipelineAssertionShouldWorkCorrectlyWithActionVersioning()
         {
             MyPipeline
                 .Configuration()
                 .ShouldMap("api/v3.0/versioning")
                 .To<VersioningController>(c => c.SpecificVersion())
+                .Which()
+                .ShouldReturn()
+                .Ok();
+        }
+
+        [Fact]
+        public void PipelineAssertionShouldWorkCorrectlyWithHeaderVersioning()
+        {
+            MyPipeline
+                .Configuration()
+                .ShouldMap(request => request
+                    .WithLocation("api/header-versioning")
+                    .WithHeader("x-api-version", "1.0"))
+                .To<HeaderVersioningController>(c => c.Index())
+                .Which()
+                .ShouldReturn()
+                .Ok();
+        }
+
+        [Fact]
+        public void PipelineAssertionShouldWorkCorrectlyWithVersionNeutralQueryController()
+        {
+            MyPipeline
+                .Configuration()
+                .ShouldMap("api/neutral-query?api-version=99.0")
+                .To<NeutralQueryController>(c => c.Index())
+                .Which()
+                .ShouldReturn()
+                .Ok();
+        }
+
+        [Fact]
+        public void PipelineAssertionShouldWorkCorrectlyWithVersionNeutralHeaderController()
+        {
+            MyPipeline
+                .Configuration()
+                .ShouldMap(request => request
+                    .WithLocation("api/neutral-header")
+                    .WithHeader("x-api-version", "99.0"))
+                .To<NeutralHeaderController>(c => c.Index())
+                .Which()
+                .ShouldReturn()
+                .Ok();
+        }
+
+        [Fact]
+        public void PipelineAssertionShouldWorkCorrectlyWithUrlSegmentCompetingV1()
+        {
+            MyPipeline
+                .Configuration()
+                .ShouldMap("api/v1.0/competing")
+                .To<UrlCompetingV1Controller>(c => c.Index())
+                .Which()
+                .ShouldReturn()
+                .Ok();
+        }
+
+        [Fact]
+        public void PipelineAssertionShouldWorkCorrectlyWithUrlSegmentCompetingV2()
+        {
+            MyPipeline
+                .Configuration()
+                .ShouldMap("api/v2.0/competing")
+                .To<UrlCompetingV2Controller>(c => c.Index())
+                .Which()
+                .ShouldReturn()
+                .Ok();
+        }
+
+        [Fact]
+        public void PipelineAssertionShouldWorkCorrectlyWithQueryCompetingV1()
+        {
+            MyPipeline
+                .Configuration()
+                .ShouldMap("api/query-competing?api-version=1.0")
+                .To<QueryCompetingV1Controller>(c => c.Index())
+                .Which()
+                .ShouldReturn()
+                .Ok();
+        }
+
+        [Fact]
+        public void PipelineAssertionShouldWorkCorrectlyWithQueryCompetingV2()
+        {
+            MyPipeline
+                .Configuration()
+                .ShouldMap("api/query-competing?api-version=2.0")
+                .To<QueryCompetingV2Controller>(c => c.Index())
+                .Which()
+                .ShouldReturn()
+                .Ok();
+        }
+
+        [Fact]
+        public void PipelineAssertionShouldWorkCorrectlyWithHeaderCompetingV1()
+        {
+            MyPipeline
+                .Configuration()
+                .ShouldMap(request => request
+                    .WithLocation("api/header-competing")
+                    .WithHeader("x-api-version", "1.0"))
+                .To<HeaderCompetingV1Controller>(c => c.Index())
+                .Which()
+                .ShouldReturn()
+                .Ok();
+        }
+
+        [Fact]
+        public void PipelineAssertionShouldWorkCorrectlyWithHeaderCompetingV2()
+        {
+            MyPipeline
+                .Configuration()
+                .ShouldMap(request => request
+                    .WithLocation("api/header-competing")
+                    .WithHeader("x-api-version", "2.0"))
+                .To<HeaderCompetingV2Controller>(c => c.Index())
                 .Which()
                 .ShouldReturn()
                 .Ok();

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/BuildersTests/PipelineTests/WhichControllerInstanceBuilderTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/BuildersTests/PipelineTests/WhichControllerInstanceBuilderTests.cs
@@ -22,7 +22,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.PipelineTests
         {
             MyPipeline
                 .Configuration()
-                .ShouldMap("api/versioning?api-version=2.0")
+                .ShouldMap("api/versioning?v=2.0")
                 .To<QueryVersioningController>(c => c.Index())
                 .Which()
                 .ShouldReturn()
@@ -48,7 +48,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.PipelineTests
                 .Configuration()
                 .ShouldMap(request => request
                     .WithLocation("api/header-versioning")
-                    .WithHeader("x-api-version", "1.0"))
+                    .WithHeader("X-Custom-Version", "1.0"))
                 .To<HeaderVersioningController>(c => c.Index())
                 .Which()
                 .ShouldReturn()
@@ -60,7 +60,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.PipelineTests
         {
             MyPipeline
                 .Configuration()
-                .ShouldMap("api/neutral-query?api-version=99.0")
+                .ShouldMap("api/neutral-query?v=99.0")
                 .To<NeutralQueryController>(c => c.Index())
                 .Which()
                 .ShouldReturn()
@@ -74,7 +74,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.PipelineTests
                 .Configuration()
                 .ShouldMap(request => request
                     .WithLocation("api/neutral-header")
-                    .WithHeader("x-api-version", "99.0"))
+                    .WithHeader("X-Custom-Version", "99.0"))
                 .To<NeutralHeaderController>(c => c.Index())
                 .Which()
                 .ShouldReturn()
@@ -110,7 +110,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.PipelineTests
         {
             MyPipeline
                 .Configuration()
-                .ShouldMap("api/query-competing?api-version=1.0")
+                .ShouldMap("api/query-competing?v=1.0")
                 .To<QueryCompetingV1Controller>(c => c.Index())
                 .Which()
                 .ShouldReturn()
@@ -122,7 +122,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.PipelineTests
         {
             MyPipeline
                 .Configuration()
-                .ShouldMap("api/query-competing?api-version=2.0")
+                .ShouldMap("api/query-competing?v=2.0")
                 .To<QueryCompetingV2Controller>(c => c.Index())
                 .Which()
                 .ShouldReturn()
@@ -136,7 +136,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.PipelineTests
                 .Configuration()
                 .ShouldMap(request => request
                     .WithLocation("api/header-competing")
-                    .WithHeader("x-api-version", "1.0"))
+                    .WithHeader("X-Custom-Version", "1.0"))
                 .To<HeaderCompetingV1Controller>(c => c.Index())
                 .Which()
                 .ShouldReturn()
@@ -150,7 +150,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.PipelineTests
                 .Configuration()
                 .ShouldMap(request => request
                     .WithLocation("api/header-competing")
-                    .WithHeader("x-api-version", "2.0"))
+                    .WithHeader("X-Custom-Version", "2.0"))
                 .To<HeaderCompetingV2Controller>(c => c.Index())
                 .Which()
                 .ShouldReturn()

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/BuildersTests/RoutingTests/RouteTestBuilderTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/BuildersTests/RoutingTests/RouteTestBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
+namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
 {
     using Setups.Controllers;
     using Xunit;
@@ -42,12 +42,159 @@
         }
 
         [Fact]
-        public void RouteAssertionShouldWorkCorrectlyWithActionVersioningWhichDoesNotExist()
+        public void RouteAssertionShouldWorkCorrectlyWithActionVersioning()
         {
             MyRouting
                 .Configuration()
                 .ShouldMap("api/v3.0/versioning")
                 .To<VersioningController>(c => c.SpecificVersion());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithHeaderVersioning()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap(request => request
+                    .WithLocation("api/header-versioning")
+                    .WithHeader("x-api-version", "1.0"))
+                .To<HeaderVersioningController>(c => c.Index());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithHeaderVersioningWhichDoesNotExist()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap(request => request
+                    .WithLocation("api/header-versioning")
+                    .WithHeader("x-api-version", "2.0"))
+                .ToNonExistingRoute();
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithVersionNeutralQueryController()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap("api/neutral-query?api-version=99.0")
+                .To<NeutralQueryController>(c => c.Index());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithVersionNeutralQueryControllerWithoutVersion()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap("api/neutral-query")
+                .To<NeutralQueryController>(c => c.Index());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithVersionNeutralHeaderController()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap(request => request
+                    .WithLocation("api/neutral-header")
+                    .WithHeader("x-api-version", "99.0"))
+                .To<NeutralHeaderController>(c => c.Index());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithVersionNeutralHeaderControllerWithoutVersion()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap("api/neutral-header")
+                .To<NeutralHeaderController>(c => c.Index());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithUrlSegmentCompetingV1()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap("api/v1.0/competing")
+                .To<UrlCompetingV1Controller>(c => c.Index());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithUrlSegmentCompetingV2()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap("api/v2.0/competing")
+                .To<UrlCompetingV2Controller>(c => c.Index());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithUrlSegmentCompetingNonExistentVersion()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap("api/v3.0/competing")
+                .ToNonExistingRoute();
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithQueryCompetingV1()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap("api/query-competing?api-version=1.0")
+                .To<QueryCompetingV1Controller>(c => c.Index());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithQueryCompetingV2()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap("api/query-competing?api-version=2.0")
+                .To<QueryCompetingV2Controller>(c => c.Index());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithQueryCompetingNonExistentVersion()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap("api/query-competing?api-version=3.0")
+                .ToNonExistingRoute();
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithHeaderCompetingV1()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap(request => request
+                    .WithLocation("api/header-competing")
+                    .WithHeader("x-api-version", "1.0"))
+                .To<HeaderCompetingV1Controller>(c => c.Index());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithHeaderCompetingV2()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap(request => request
+                    .WithLocation("api/header-competing")
+                    .WithHeader("x-api-version", "2.0"))
+                .To<HeaderCompetingV2Controller>(c => c.Index());
+        }
+
+        [Fact]
+        public void RouteAssertionShouldWorkCorrectlyWithHeaderCompetingNonExistentVersion()
+        {
+            MyRouting
+                .Configuration()
+                .ShouldMap(request => request
+                    .WithLocation("api/header-competing")
+                    .WithHeader("x-api-version", "3.0"))
+                .ToNonExistingRoute();
         }
     }
 }

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/BuildersTests/RoutingTests/RouteTestBuilderTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/BuildersTests/RoutingTests/RouteTestBuilderTests.cs
@@ -28,7 +28,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
         {
             MyRouting
                 .Configuration()
-                .ShouldMap("api/versioning?api-version=2.0")
+                .ShouldMap("api/versioning?v=2.0")
                 .To<QueryVersioningController>(c => c.Index());
         }
 
@@ -37,7 +37,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
         {
             MyRouting
                 .Configuration()
-                .ShouldMap("api/versioning?api-version=1.0")
+                .ShouldMap("api/versioning?v=1.0")
                 .ToNonExistingRoute();
         }
 
@@ -57,7 +57,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
                 .Configuration()
                 .ShouldMap(request => request
                     .WithLocation("api/header-versioning")
-                    .WithHeader("x-api-version", "1.0"))
+                    .WithHeader("X-Custom-Version", "1.0"))
                 .To<HeaderVersioningController>(c => c.Index());
         }
 
@@ -68,7 +68,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
                 .Configuration()
                 .ShouldMap(request => request
                     .WithLocation("api/header-versioning")
-                    .WithHeader("x-api-version", "2.0"))
+                    .WithHeader("X-Custom-Version", "2.0"))
                 .ToNonExistingRoute();
         }
 
@@ -77,7 +77,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
         {
             MyRouting
                 .Configuration()
-                .ShouldMap("api/neutral-query?api-version=99.0")
+                .ShouldMap("api/neutral-query?v=99.0")
                 .To<NeutralQueryController>(c => c.Index());
         }
 
@@ -97,7 +97,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
                 .Configuration()
                 .ShouldMap(request => request
                     .WithLocation("api/neutral-header")
-                    .WithHeader("x-api-version", "99.0"))
+                    .WithHeader("X-Custom-Version", "99.0"))
                 .To<NeutralHeaderController>(c => c.Index());
         }
 
@@ -142,7 +142,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
         {
             MyRouting
                 .Configuration()
-                .ShouldMap("api/query-competing?api-version=1.0")
+                .ShouldMap("api/query-competing?v=1.0")
                 .To<QueryCompetingV1Controller>(c => c.Index());
         }
 
@@ -151,7 +151,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
         {
             MyRouting
                 .Configuration()
-                .ShouldMap("api/query-competing?api-version=2.0")
+                .ShouldMap("api/query-competing?v=2.0")
                 .To<QueryCompetingV2Controller>(c => c.Index());
         }
 
@@ -160,7 +160,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
         {
             MyRouting
                 .Configuration()
-                .ShouldMap("api/query-competing?api-version=3.0")
+                .ShouldMap("api/query-competing?v=3.0")
                 .ToNonExistingRoute();
         }
 
@@ -171,7 +171,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
                 .Configuration()
                 .ShouldMap(request => request
                     .WithLocation("api/header-competing")
-                    .WithHeader("x-api-version", "1.0"))
+                    .WithHeader("X-Custom-Version", "1.0"))
                 .To<HeaderCompetingV1Controller>(c => c.Index());
         }
 
@@ -182,7 +182,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
                 .Configuration()
                 .ShouldMap(request => request
                     .WithLocation("api/header-competing")
-                    .WithHeader("x-api-version", "2.0"))
+                    .WithHeader("X-Custom-Version", "2.0"))
                 .To<HeaderCompetingV2Controller>(c => c.Index());
         }
 
@@ -193,7 +193,7 @@ namespace MyTested.AspNetCore.Mvc.Test.BuildersTests.RoutingTests
                 .Configuration()
                 .ShouldMap(request => request
                     .WithLocation("api/header-competing")
-                    .WithHeader("x-api-version", "3.0"))
+                    .WithHeader("X-Custom-Version", "3.0"))
                 .ToNonExistingRoute();
         }
     }

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/PluginsTests/VersioningTestPluginTests.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/PluginsTests/VersioningTestPluginTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace MyTested.AspNetCore.Mvc.Test.PluginsTests
 {
     using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc.Versioning;
+    using Asp.Versioning;
     using Plugins;
     using Xunit;
 

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/HeaderCompetingV1Controller.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/HeaderCompetingV1Controller.cs
@@ -1,0 +1,14 @@
+namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc;
+
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("api/header-competing")]
+    public class HeaderCompetingV1Controller : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Index() => this.Ok();
+    }
+}

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/HeaderCompetingV2Controller.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/HeaderCompetingV2Controller.cs
@@ -1,0 +1,14 @@
+namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc;
+
+    [ApiController]
+    [ApiVersion("2.0")]
+    [Route("api/header-competing")]
+    public class HeaderCompetingV2Controller : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Index() => this.Ok();
+    }
+}

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/HeaderVersioningController.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/HeaderVersioningController.cs
@@ -1,0 +1,14 @@
+namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc;
+
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("api/header-versioning")]
+    public class HeaderVersioningController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Index() => this.Ok();
+    }
+}

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/NeutralHeaderController.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/NeutralHeaderController.cs
@@ -1,0 +1,14 @@
+namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc;
+
+    [ApiController]
+    [ApiVersionNeutral]
+    [Route("api/neutral-header")]
+    public class NeutralHeaderController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Index() => this.Ok();
+    }
+}

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/NeutralQueryController.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/NeutralQueryController.cs
@@ -1,0 +1,14 @@
+namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc;
+
+    [ApiController]
+    [ApiVersionNeutral]
+    [Route("api/neutral-query")]
+    public class NeutralQueryController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Index() => this.Ok();
+    }
+}

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/QueryCompetingV1Controller.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/QueryCompetingV1Controller.cs
@@ -1,0 +1,14 @@
+namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc;
+
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("api/query-competing")]
+    public class QueryCompetingV1Controller : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Index() => this.Ok();
+    }
+}

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/QueryCompetingV2Controller.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/QueryCompetingV2Controller.cs
@@ -1,0 +1,14 @@
+namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc;
+
+    [ApiController]
+    [ApiVersion("2.0")]
+    [Route("api/query-competing")]
+    public class QueryCompetingV2Controller : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Index() => this.Ok();
+    }
+}

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/QueryVersioningController.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/QueryVersioningController.cs
@@ -1,5 +1,6 @@
 ﻿namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
 {
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Mvc;
 
     [ApiController]

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/UrlCompetingV1Controller.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/UrlCompetingV1Controller.cs
@@ -1,0 +1,14 @@
+namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc;
+
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/competing")]
+    public class UrlCompetingV1Controller : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Index() => this.Ok();
+    }
+}

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/UrlCompetingV2Controller.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/UrlCompetingV2Controller.cs
@@ -1,0 +1,14 @@
+namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Mvc;
+
+    [ApiController]
+    [ApiVersion("2.0")]
+    [Route("api/v{version:apiVersion}/competing")]
+    public class UrlCompetingV2Controller : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Index() => this.Ok();
+    }
+}

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/VersioningController.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/Setups/Controllers/VersioningController.cs
@@ -1,5 +1,6 @@
 ﻿namespace MyTested.AspNetCore.Mvc.Test.Setups.Controllers
 {
+    using Asp.Versioning;
     using Microsoft.AspNetCore.Mvc;
 
     [ApiController]

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/TestStartup.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/TestStartup.cs
@@ -8,7 +8,7 @@
         public override void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers();
-            services.AddApiVersioning();
+            services.AddApiVersioning().AddMvc();
         }
     }
 }

--- a/test/MyTested.AspNetCore.Mvc.Versioning.Test/TestStartup.cs
+++ b/test/MyTested.AspNetCore.Mvc.Versioning.Test/TestStartup.cs
@@ -1,5 +1,6 @@
-﻿namespace MyTested.AspNetCore.Mvc.Test
+namespace MyTested.AspNetCore.Mvc.Test
 {
+    using Asp.Versioning;
     using Microsoft.Extensions.DependencyInjection;
     using Setups;
 
@@ -8,7 +9,13 @@
         public override void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers();
-            services.AddApiVersioning().AddMvc();
+            services.AddApiVersioning(options =>
+            {
+                options.ApiVersionReader = ApiVersionReader.Combine(
+                    new QueryStringApiVersionReader("v"),
+                    new HeaderApiVersionReader("X-Custom-Version"),
+                    new UrlSegmentApiVersionReader());
+            }).AddMvc();
         }
     }
 }


### PR DESCRIPTION
## Overview

 - Revise API Versioning Support from `Microsoft.AspNetCore.Mvc.Versioning` v5.1.0 to `Asp.Versioning.Mvc` v8.1.1
 - Add Support for HTTP Header version resolution
 - Add support for developer-defined querystring or HTTP Header version-resolution keys.

This will close #421

## Details

The `MyTested.AspNetCore.Mvc.Versioning` plugin currently depends on the deprecated `Microsoft.AspNetCore.Mvc.Versioning` v5.1.0. The replacement package is `Asp.Versioning.Mvc`, currently in v8.1.1. The challenge is that the old package registered a custom `ApiVersionActionSelector` as `IActionSelector` which handled version-aware action filtering in the legacy routing pipeline. The new package no longer provides this; it relies on `ApiVersionMatcherPolicy` via endpoint routing. Since MyTested disables endpoint routing (`EnableEndpointRouting = false`), version filtering won't happen, causing ambiguous match errors.

The solution is to swap packages to `Asp.Versioning.Mvc`, update namespaces, and implement a custom `IActionSelector` decorator in the plugin that restores version-aware action selection.

## Further Enhancements

Further, because `Asp.Versioning` allows developers to resolve version by HTTP Header, and also allows developers to configure custom keys via `ApiVersioningOptions.ApiVersionReader` (e.g., `QueryStringApiVersionReader("v")`, `HeaderApiVersionReader("X-Custom-Version")`), we have enhanced the `GetRequestedApiVersion` methods to support Header resolution and to read the configured keys from the library's own `IApiVersionReader` at request time using `IOptions<ApiVersioningOptions>`.